### PR TITLE
Feat[#14]: 공용 태그 컴포넌트 구현, 공용 배지 컴포넌트 구현

### DIFF
--- a/src/components/commons/Badge/Badge.module.scss
+++ b/src/components/commons/Badge/Badge.module.scss
@@ -1,0 +1,36 @@
+%badge-base {
+  @include flexbox;
+  @include text-style(14, $gray40, bold);
+
+  height: 2.2rem;
+  padding: 0 0.8rem;
+  background-color: $opacity-white-5;
+  border-radius: 0.4rem;
+}
+
+.badge-pending {
+  @extend %badge-base;
+
+  color: $skyblue;
+}
+.badge-confirmed {
+  @extend %badge-base;
+
+  color: $blue;
+}
+.badge-declined {
+  @extend %badge-base;
+
+  color: $orange;
+}
+.badge-canceled {
+  @extend %badge-base;
+
+  color: $red;
+}
+.badge-completed {
+  @extend %badge-base;
+
+  background-color: transparent;
+  border: 0.1rem solid $gray40;
+}

--- a/src/components/commons/Badge/index.tsx
+++ b/src/components/commons/Badge/index.tsx
@@ -1,0 +1,19 @@
+import classNames from 'classnames/bind';
+
+import { formatStatusToKorea } from '@/utils';
+
+import { MyReservationsStatus } from '@/types';
+
+import styles from './Badge.module.scss';
+
+const cx = classNames.bind(styles);
+
+type BadgeProps = {
+  status: MyReservationsStatus;
+};
+
+const Badge = ({ status }: BadgeProps) => {
+  return <div className={cx(`badge-${status}`)}>{formatStatusToKorea(status)}</div>;
+};
+
+export default Badge;

--- a/src/components/commons/Tag/Tag.module.scss
+++ b/src/components/commons/Tag/Tag.module.scss
@@ -1,0 +1,22 @@
+%tag-base {
+  @include flexbox;
+  @include text-style(12, $black50, bold);
+
+  width: 7.2rem;
+  height: 2.2rem;
+  text-transform: uppercase;
+  border-radius: 0.4rem;
+}
+
+.tag-offline {
+  @extend %tag-base;
+
+  background-color: $primary;
+}
+
+.tag-online {
+  @extend %tag-base;
+
+  color: $primary;
+  background-color: $black;
+}

--- a/src/components/commons/Tag/index.tsx
+++ b/src/components/commons/Tag/index.tsx
@@ -1,0 +1,17 @@
+import classNames from 'classnames/bind';
+
+import styles from './Tag.module.scss';
+
+const cx = classNames.bind(styles);
+
+type TagProps = {
+  price: number;
+};
+
+const Tag = ({ price }: TagProps) => {
+  const recruitmentType = price === 0 ? 'offline' : 'online';
+
+  return <div className={cx(`tag-${recruitmentType}`)}>{recruitmentType}</div>;
+};
+
+export default Tag;

--- a/src/utils/formatStatusToKorea.ts
+++ b/src/utils/formatStatusToKorea.ts
@@ -1,0 +1,9 @@
+import { MyReservationsStatus } from '@/types';
+
+export const formatStatusToKorea = (status: MyReservationsStatus) => {
+  if (status === 'pending') return '신청';
+  if (status === 'confirmed') return '승인';
+  if (status === 'declined') return '거절';
+  if (status === 'canceled') return '취소';
+  if (status === 'completed') return '종료';
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './getDiffDate';
 export * from './router';
+export * from './formatStatusToKorea';


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #14 
- close #14 

## 유형

- [ ] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- [UI 구현] 공용 태그 컴포넌트 구현
- [UI 구현] 공용 배지 컴포넌트 구현

### 설명

### 1️⃣ 태그 컴포넌트
-  price, totalPrice의 recruitmentType은 아래와 같습니다.
- ⚠️ 특이사항) 내 체험 예약 totalPrice = price * headCount
- price === 0 : 오프라인
- price === 1 : 온라인 
- totalPrice === 0 : 오프라인
- totalPrice > 0 : 온라인

```jsx
const recruitmentType = price === 0 ? 'offline' : 'online';
```
👉 props
```jsx
type TagProps = {
  price: number;
};
```

### 2️⃣ 배지 컴포넌트
👉 props
```jsx
status: 'pending' | 'confirmed' | 'completed' | 'declined' | 'canceled';
```

- status 프롭을 한국말로 반환하는 훅 생성
- 배지 text에 적용해서 status만 프롭으로 잘 넘겨주면 됩니다.

### 📝 코드 예시
```jsx
<Tag price={price} />
<Badge status={status} />
```

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
📷 컴포넌트 구현 스크린샷
<img width="901" alt="스크린샷 2024-03-07 오후 3 17 28" src="https://github.com/sprint-team3/GGF/assets/77719310/4bdc6980-e16a-4038-a75b-6a54125470f6">


## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
