### PR TITLE
Feat[#4] : useSignin, signout, queryClient 구현

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,3 +3,4 @@ export * from './images';
 export * from './paging';
 export * from './auth';
 export * from './myReservationsStatus';
+export * from './queryClient';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,5 @@
 export * from './apiPaths';
 export * from './images';
 export * from './paging';
-// export * from './auth';
+export * from './auth';
 export * from './myReservationsStatus';

--- a/src/constants/queryClient.ts
+++ b/src/constants/queryClient.ts
@@ -1,0 +1,1 @@
+export const QUERY_CLIENT_STALE_TIME = 1000 * (60 * 30);

--- a/src/hooks/useSignin.ts
+++ b/src/hooks/useSignin.ts
@@ -4,6 +4,8 @@ import Cookies from 'js-cookie';
 import { Auth } from '@/apis/auth';
 import { ACCESS_TOKEN_EXPIRED_TIME, REFRESH_TOKEN_EXPIRED_TIME } from '@/constants';
 
+import useUserStore from '@/stores/useUserStore';
+
 import { Account } from '@/types';
 
 const useSignin = (value: Account) => {
@@ -12,7 +14,7 @@ const useSignin = (value: Account) => {
   });
 
   if (data) {
-    const { accessToken, refreshToken } = data.data;
+    const { accessToken, refreshToken, user } = data.data;
     Cookies.set('accessToken', accessToken, {
       expires: ACCESS_TOKEN_EXPIRED_TIME,
       secure: true,
@@ -23,6 +25,7 @@ const useSignin = (value: Account) => {
       secure: true,
       sameSite: 'strict',
     });
+    useUserStore.setState({ user: user });
   }
 
   return { isError, mutate };

--- a/src/hooks/useSignin.ts
+++ b/src/hooks/useSignin.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+import Cookies from 'js-cookie';
+
+import { Auth } from '@/apis/auth';
+import { ACCESS_TOKEN_EXPIRED_TIME, REFRESH_TOKEN_EXPIRED_TIME } from '@/constants';
+
+import { Account } from '@/types';
+
+const useSignin = (value: Account) => {
+  const { data, isError, mutate } = useMutation({
+    mutationFn: () => Auth.signin(value),
+  });
+
+  if (data) {
+    const { accessToken, refreshToken } = data.data;
+    Cookies.set('accessToken', accessToken, {
+      expires: ACCESS_TOKEN_EXPIRED_TIME,
+      secure: true,
+      sameSite: 'strict',
+    });
+    Cookies.set('refreshToken', refreshToken, {
+      expires: REFRESH_TOKEN_EXPIRED_TIME,
+      secure: true,
+      sameSite: 'strict',
+    });
+  }
+
+  return { isError, mutate };
+};
+
+export default useSignin;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import Modal from 'react-modal';
 
 import '@/styles/base/common.scss';
-import { queryClient } from '@/utils/queryClient';
+import { queryClient } from '@/utils';
 
 Modal.setAppElement('#__next');
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,19 @@
 import type { AppProps } from 'next/app';
 
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import Modal from 'react-modal';
+
 import '@/styles/base/common.scss';
+import { queryClient } from '@/utils/queryClient';
 
 Modal.setAppElement('#__next');
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={false} />
+      <Component {...pageProps} />
+    </QueryClientProvider>
+  );
 }

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,0 +1,7 @@
+import { create } from 'zustand';
+
+const useUserStore = create(() => ({
+  user: null,
+}));
+
+export default useUserStore;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
 export * from './getDiffDate';
 export * from './router';
 export * from './formatStatusToKR';
+export * from './queryClient';
+export * from './signout';

--- a/src/utils/queryClient.ts
+++ b/src/utils/queryClient.ts
@@ -1,0 +1,14 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 & (60 * 30),
+      refetchOnWindowFocus: false,
+      retry: 0,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});

--- a/src/utils/queryClient.ts
+++ b/src/utils/queryClient.ts
@@ -1,9 +1,11 @@
 import { QueryClient } from '@tanstack/react-query';
 
+import { QUERY_CLIENT_STALE_TIME } from '@/constants';
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 & (60 * 30),
+      staleTime: QUERY_CLIENT_STALE_TIME,
       refetchOnWindowFocus: false,
       retry: 0,
     },

--- a/src/utils/signout.ts
+++ b/src/utils/signout.ts
@@ -1,9 +1,9 @@
 import Cookies from 'js-cookie';
 
-import { replaceToPage } from './router';
+import useUserStore from '@/stores/useUserStore';
 
 export const signout = () => {
   Cookies.remove('accessToken');
   Cookies.remove('refreshToken');
-  replaceToPage('/signin');
+  useUserStore.setState({ user: null });
 };

--- a/src/utils/signout.ts
+++ b/src/utils/signout.ts
@@ -1,0 +1,9 @@
+import Cookies from 'js-cookie';
+
+import { replaceToPage } from './router';
+
+export const signout = () => {
+  Cookies.remove('accessToken');
+  Cookies.remove('refreshToken');
+  replaceToPage('/signin');
+};


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #4
- close #4

## 유형

- [x] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

### 1️⃣ react query provider 적용
- app.tsx에서 provider 사용
- react query devtools 사용
- queryClient 생성. 옵션 값은 상의 후 변경

### 2️⃣ signin 로직 구현
- useSignin hook 구현
- useMutation사용
- response로 온 accessToken과 refreshToken을 쿠키에 저장(js-cookie 라이브러리 사용)
- useUserStore에 유저 정보 저장
- isError, mutation 리턴 


### 3️⃣ signout  로직 구현
- utils/signout.ts 구현
- 모든 토큰 쿠키에서 제거
- useUserStore에서 유저 정보 삭제

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->
- queryClient 옵션 설정이 더 필요할 것 같습니다. 회의 시간에 같이 수정하면 좋을 것 같습니다!
- signout 함수에서 보완하거나 수정할 부분이 있을까요?
제가 생각했을 때는 로그아웃시 모든 토큰을 제거하고 로그인 화면으로 이동시키는 게 자연스럽다고 생각하여 이렇게 구현하였습니다.
- 이외에도 수정할 부분이 있거나 코드 관련 궁금한 부분이 있으시면 편하게 코멘트 부탁드립니다😃
