### PR TITLE
Feat[#45]: 공용 TextField 컴포넌트 구현

### DIFF
--- a/src/components/commons/TextField/TextField.module.scss
+++ b/src/components/commons/TextField/TextField.module.scss
@@ -1,0 +1,58 @@
+.text-field {
+  width: 100%;
+
+  &-label {
+    @include text-style(14, $white);
+
+    display: block;
+    padding-bottom: 0.8rem;
+  }
+
+  &-text-group {
+    @include column-flexbox($gap: 0.8rem);
+
+    width: 100%;
+    height: 16.6rem;
+    padding: 1.2rem;
+
+    background: $black70;
+    border: 0.1rem solid $black50;
+    border-radius: 0.8rem;
+
+    transition: $base-transition;
+
+    &.focused {
+      border-color: $purple;
+    }
+
+    &.error {
+      border-color: $red;
+    }
+
+    &-textarea {
+      @include text-style(14, $gray10);
+      @include thick-scrollbar;
+
+      resize: none;
+      width: 100%;
+      height: 12rem;
+      padding-right: 1.4rem;
+    }
+
+    &-footer {
+      width: 100%;
+      height: 1.4rem;
+      margin-left: auto;
+      text-align: right;
+
+      &-current-num,
+      &-total-num {
+        @include text-style(12, $gray50);
+      }
+
+      .active {
+        color: $gray10;
+      }
+    }
+  }
+}

--- a/src/components/commons/TextField/index.tsx
+++ b/src/components/commons/TextField/index.tsx
@@ -1,4 +1,5 @@
-import { ChangeEvent, KeyboardEvent, useState } from 'react';
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import { ChangeEvent, useState } from 'react';
 
 import classNames from 'classnames/bind';
 import { useFormContext } from 'react-hook-form';
@@ -20,8 +21,8 @@ const TextField = ({ label, name, maxLength = 700, ...props }: TextFieldProps) =
     register,
     formState: { errors },
   } = useFormContext();
-  const [textcount, setTextcount] = useState<number>(0);
-  const [isFocused, setIsFocused] = useState<boolean>(false);
+  const [textCount, setTextCount] = useState(0);
+  const [isFocused, setIsFocused] = useState(false);
 
   const isError = !!errors[name]?.message;
 
@@ -33,16 +34,8 @@ const TextField = ({ label, name, maxLength = 700, ...props }: TextFieldProps) =
     setIsFocused(false);
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key == 'Enter') {
-      if (!setIsFocused) {
-        handleClick();
-      }
-    }
-  };
-
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    setTextcount(event.target.textLength);
+    setTextCount(event.target.textLength);
   };
 
   return (
@@ -54,7 +47,6 @@ const TextField = ({ label, name, maxLength = 700, ...props }: TextFieldProps) =
         tabIndex={0}
         onClick={handleClick}
         onBlur={handleBlur}
-        onKeyDown={handleKeyDown}
       >
         <textarea
           className={cx('text-field-text-group-textarea')}
@@ -64,7 +56,7 @@ const TextField = ({ label, name, maxLength = 700, ...props }: TextFieldProps) =
           {...props}
         />
         <div className={cx('text-field-text-group-footer')}>
-          <span className={cx('text-field-text-group-footer-current-num', { active: textcount > 0 })}>{textcount}</span>
+          <span className={cx('text-field-text-group-footer-current-num', { active: textCount > 0 })}>{textCount}</span>
           <span className={cx('text-field-text-group-footer-total-num')}>/{maxLength}</span>
         </div>
       </div>

--- a/src/components/commons/TextField/index.tsx
+++ b/src/components/commons/TextField/index.tsx
@@ -1,0 +1,75 @@
+import { ChangeEvent, KeyboardEvent, useState } from 'react';
+
+import classNames from 'classnames/bind';
+import { useFormContext } from 'react-hook-form';
+
+import styles from './TextField.module.scss';
+
+const cx = classNames.bind(styles);
+
+type TextFieldProps = {
+  label: string;
+  name: string;
+  maxLength?: number;
+  placeholder?: string;
+  autocomplete?: boolean;
+};
+
+const TextField = ({ label, name, maxLength = 700, ...props }: TextFieldProps) => {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext();
+  const [textcount, setTextcount] = useState<number>(0);
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
+  const isError = !!errors[name]?.message;
+
+  const handleClick = () => {
+    setIsFocused(true);
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key == 'Enter') {
+      if (!setIsFocused) {
+        handleClick();
+      }
+    }
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setTextcount(event.target.textLength);
+  };
+
+  return (
+    <div className={cx('text-field')}>
+      <label className={cx('text-field-label')}>{label}</label>
+      <div
+        className={cx('text-field-text-group', { error: isError }, { focused: isFocused })}
+        role='textbox'
+        tabIndex={0}
+        onClick={handleClick}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+      >
+        <textarea
+          className={cx('text-field-text-group-textarea')}
+          {...register(name, {
+            onChange: (event) => handleChange(event),
+          })}
+          {...props}
+        />
+        <div className={cx('text-field-text-group-footer')}>
+          <span className={cx('text-field-text-group-footer-current-num', { active: textcount > 0 })}>{textcount}</span>
+          <span className={cx('text-field-text-group-footer-total-num')}>/{maxLength}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TextField;

--- a/src/styles/mixins/_scrollbar.scss
+++ b/src/styles/mixins/_scrollbar.scss
@@ -1,5 +1,32 @@
+%scrollbar-base {
+  &::-webkit-scrollbar-thumb {
+    background-color: $gray60;
+    border-radius: 1rem;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+}
+
 @mixin no-scrollbar() {
   &::-webkit-scrollbar {
     display: none;
+  }
+}
+
+@mixin thick-scrollbar() {
+  @extend %scrollbar-base;
+
+  &::-webkit-scrollbar {
+    width: 0.6rem;
+  }
+}
+
+@mixin thin-scrollbar() {
+  @extend %scrollbar-base;
+
+  &::-webkit-scrollbar {
+    width: 0.4rem;
   }
 }


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #45 
- close #45

## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

### TextField 컴포넌트
- InputField와 같이 react hook form 적용하였고, 사용하는 컴포넌트에서 FormProvider로 form을 씌워주고, useForm에서 methods 설정해주셔야 합니다.
- 구체적인 사용법은 추후 노션에 올리겠습니다.

#### props
1. label : 제목입니다.
2. name : 데이터 전송 및 유효성 검사때 사용되는 이름입니다. 
3. maxLength : 최대 길이로 기본값은 700자입니다.
4. placeholder 
5. autocomplete

#### scroll bar mixin 추가
- TextField에서 사용하는 두꺼운 스크롤바와 select box에서 사용하는 얇은 스크롤바를 믹스인에 추가했습니다.

#### 특이한 점
- textarea와 글자수를 보여주는 div를 div로 감쌌습니다.
- focus시 border 컬러를 바꿔줘야하는 기능 때문에 isFocused라는 useState를 사용했습니다.
- div는 원래 인터렉션이 일어나면 안 되는 태그이지만, 부득이하게 이렇게 클릭 이벤트를 넣었습니다.  대신 웹접근성을 위해 tabIndex와  onKeyDown 이벤트를 추가했습니다. 이것들을 빼버리면 a11y에서 감지하는 오류가 발생합니다.

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### default
![image](https://github.com/sprint-team3/GGF/assets/92169354/d73f6bf4-57c8-4305-a618-381ca6c0070e)

### error
![image](https://github.com/sprint-team3/GGF/assets/92169354/23f21b58-aab1-427c-b12c-937f416a9ca0)

### focus
![image](https://github.com/sprint-team3/GGF/assets/92169354/8e7abc22-5531-4251-8f41-f25efa02e60c)

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

- handleKeyDown을 우선 만들긴 했는데, 과연 실효성이 있을 지 모르겠습니다. 어떤 키를 감지해서 처리해주는 게 좋을까요? 
- autocomplete를 혹시나 쓸 수도 있을 것 같아 우선 props 타입에 추가해두었는데요, 사용하지 않을 것 같다면 빼겠습니다.
