### PR TITLE
Feat[#54]: 공용 InputRadio 컴포넌트 구현

### DIFF
--- a/src/components/commons/InputRadio/InputRadio.module.scss
+++ b/src/components/commons/InputRadio/InputRadio.module.scss
@@ -1,0 +1,31 @@
+.input-radio {
+  @include flexbox(start, center, 1.6rem);
+
+  &-option-container {
+    @include flexbox(start, center, 0.8rem);
+
+    input[type='radio'] {
+      cursor: pointer;
+
+      width: 1.8rem;
+      height: 1.8rem;
+
+      appearance: none;
+      background: $white;
+      border: 0.4rem solid $gray30;
+      border-radius: 50%;
+      outline: none;
+    }
+
+    input[type='radio']:checked {
+      background-color: $white;
+      border: 0.4rem solid $purple;
+    }
+
+    &-label {
+      @include text-style(14, $gray10);
+
+      cursor: pointer;
+    }
+  }
+}

--- a/src/components/commons/InputRadio/InputRadio.module.scss
+++ b/src/components/commons/InputRadio/InputRadio.module.scss
@@ -1,31 +1,42 @@
 .input-radio {
-  @include flexbox(start, center, 1.6rem);
+  @include column-flexbox(start, start, 0.8rem);
 
-  &-option-container {
-    @include flexbox(start, center, 0.8rem);
+  &-label {
+    @include text-style(14, $white);
+  }
 
-    input[type='radio'] {
-      cursor: pointer;
+  &-group {
+    @include flexbox(start, center, 1.6rem);
 
-      width: 1.8rem;
-      height: 1.8rem;
+    width: 100%;
+    height: 4.8rem;
 
-      appearance: none;
-      background: $white;
-      border: 0.4rem solid $gray30;
-      border-radius: 50%;
-      outline: none;
-    }
+    .option-container {
+      @include flexbox(start, center, 0.8rem);
 
-    input[type='radio']:checked {
-      background-color: $white;
-      border: 0.4rem solid $purple;
-    }
+      input[type='radio'] {
+        cursor: pointer;
 
-    &-label {
-      @include text-style(14, $gray10);
+        width: 1.8rem;
+        height: 1.8rem;
 
-      cursor: pointer;
+        appearance: none;
+        background: $white;
+        border: 0.4rem solid $gray30;
+        border-radius: 50%;
+        outline: none;
+      }
+
+      input[type='radio']:checked {
+        background-color: $white;
+        border: 0.4rem solid $purple;
+      }
+
+      &-label {
+        @include text-style(14, $gray10);
+
+        cursor: pointer;
+      }
     }
   }
 }

--- a/src/components/commons/InputRadio/index.tsx
+++ b/src/components/commons/InputRadio/index.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+
+import classNames from 'classnames/bind';
+import { useFormContext } from 'react-hook-form';
+
+import { RecruitTypes } from '@/constants';
+
+import styles from './InputRadio.module.scss';
+
+const cx = classNames.bind(styles);
+
+type InputRadioProps = {
+  legend: string;
+  name: string;
+};
+
+const InputRadio = ({ legend, name }: InputRadioProps) => {
+  const { register } = useFormContext();
+
+  const firstInputRef = useRef<HTMLLabelElement>(null);
+
+  useEffect(() => {
+    if (firstInputRef.current) {
+      firstInputRef.current.click();
+    }
+  }, []);
+
+  return (
+    <fieldset className={cx('input-radio')}>
+      <legend className={cx('input-radio-legend')}>{legend}</legend>
+      {RecruitTypes.map((option, index) => (
+        <div className={cx('input-radio-option-container')} key={option.id}>
+          <input className={cx('radio')} type='radio' id={option.id} value={option.value} {...register(name)} />
+          <label className={cx('label')} htmlFor={option.id} ref={index === 0 ? firstInputRef : null}>
+            {option.label}
+          </label>
+        </div>
+      ))}
+    </fieldset>
+  );
+};
+
+export default InputRadio;

--- a/src/components/commons/InputRadio/index.tsx
+++ b/src/components/commons/InputRadio/index.tsx
@@ -1,39 +1,40 @@
 import classNames from 'classnames/bind';
 import { useFormContext } from 'react-hook-form';
 
-import { RecruitTypes } from '@/constants';
-
 import styles from './InputRadio.module.scss';
 
 const cx = classNames.bind(styles);
 
 type InputRadioProps = {
-  legend: string;
+  label: string;
   name: string;
+  radioList: { id: string; value: number; label: string }[];
 };
 
-const InputRadio = ({ legend, name }: InputRadioProps) => {
+const InputRadio = ({ label, name, radioList }: InputRadioProps) => {
   const { register } = useFormContext();
 
   return (
-    <fieldset className={cx('input-radio')}>
-      <legend className={cx('input-radio-legend')}>{legend}</legend>
-      {RecruitTypes.map((option, index) => (
-        <div className={cx('input-radio-option-container')} key={option.id}>
-          <input
-            className={cx('radio')}
-            type='radio'
-            id={option.id}
-            value={option.value}
-            defaultChecked={index === 0}
-            {...register(name)}
-          />
-          <label className={cx('label')} htmlFor={option.id}>
-            {option.label}
-          </label>
-        </div>
-      ))}
-    </fieldset>
+    <div className={cx('input-radio')}>
+      <label className={cx('input-radio-label')}>{label}</label>
+      <div className={cx('input-radio-group')}>
+        {radioList.map((option, index) => (
+          <div className={cx('option-container')} key={option.id}>
+            <input
+              className={cx('radio')}
+              type='radio'
+              id={option.id}
+              value={option.value}
+              defaultChecked={index === 0}
+              {...register(name)}
+            />
+            <label className={cx('label')} htmlFor={option.id}>
+              {option.label}
+            </label>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 };
 

--- a/src/components/commons/InputRadio/index.tsx
+++ b/src/components/commons/InputRadio/index.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useRef } from 'react';
-
 import classNames from 'classnames/bind';
 import { useFormContext } from 'react-hook-form';
 
@@ -17,21 +15,20 @@ type InputRadioProps = {
 const InputRadio = ({ legend, name }: InputRadioProps) => {
   const { register } = useFormContext();
 
-  const firstInputRef = useRef<HTMLLabelElement>(null);
-
-  useEffect(() => {
-    if (firstInputRef.current) {
-      firstInputRef.current.click();
-    }
-  }, []);
-
   return (
     <fieldset className={cx('input-radio')}>
       <legend className={cx('input-radio-legend')}>{legend}</legend>
       {RecruitTypes.map((option, index) => (
         <div className={cx('input-radio-option-container')} key={option.id}>
-          <input className={cx('radio')} type='radio' id={option.id} value={option.value} {...register(name)} />
-          <label className={cx('label')} htmlFor={option.id} ref={index === 0 ? firstInputRef : null}>
+          <input
+            className={cx('radio')}
+            type='radio'
+            id={option.id}
+            value={option.value}
+            defaultChecked={index === 0}
+            {...register(name)}
+          />
+          <label className={cx('label')} htmlFor={option.id}>
             {option.label}
           </label>
         </div>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,3 +8,4 @@ export * from './paging';
 export * from './queryClient';
 export * from './passwordMode';
 export * from './times';
+export * from './radioOptions';

--- a/src/constants/radioOptions.ts
+++ b/src/constants/radioOptions.ts
@@ -1,0 +1,6 @@
+export const RecruitTypes = [
+  { id: 'offline', value: 0, label: '오프라인' },
+  { id: 'online', value: 1, label: '온라인' },
+  { id: 'clan-recruitment', value: 2, label: '클랜 모집' },
+  { id: 'game-strategy', value: 3, label: '게임 공략' },
+];


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #54  
- close #54

## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

### InputRadio
- 객체를 prop으로 받아 radio type input 버튼 그룹을 만드는 컴포넌트입니다.
- react hook form으로 값을 form에 넘겨줍니다.
- 페이지 로드시 첫 번째 라디오가 클릭되도록 useRef와 useState를 사용했습니다.
- fieldset과 legend를 사용해 웹 접근성을 높였습니다. 
- legend에는 input radio 옵션들에 대한 설명을 써주시면 됩니다.
- 자세한 사용법은 추후 노션에 업데이트 하겠습니다.


## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
![Uploading image.png…]()

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

1. 모집 유형 객체를 radioOptions.ts에 객체로 만들었는데, 더나은 변수명/파일명이 있을 지 궁금합니다.