### PR TITLE
Hotfix: label없을 때 focus되면 border-color primary로 변경

### DIFF
--- a/src/components/commons/inputs/TextField.module.scss
+++ b/src/components/commons/inputs/TextField.module.scss
@@ -25,6 +25,10 @@
       border-color: $purple;
     }
 
+    &.focused.non-label {
+      border-color: $primary;
+    }
+
     &.error {
       border-color: $red;
     }

--- a/src/components/commons/inputs/TextField.tsx
+++ b/src/components/commons/inputs/TextField.tsx
@@ -9,14 +9,13 @@ import styles from './TextField.module.scss';
 const cx = classNames.bind(styles);
 
 type TextFieldProps = {
-  label: string;
   name: string;
+  label?: string;
   maxLength?: number;
   placeholder?: string;
-  autocomplete?: boolean;
 };
 
-export const TextField = ({ label, name, maxLength = 700, ...props }: TextFieldProps) => {
+export const TextField = ({ name, label, maxLength = 700, ...props }: TextFieldProps) => {
   const {
     register,
     formState: { errors },
@@ -42,7 +41,7 @@ export const TextField = ({ label, name, maxLength = 700, ...props }: TextFieldP
     <div className={cx('text-field')}>
       <label className={cx('text-field-label')}>{label}</label>
       <div
-        className={cx('text-field-text-group', { error: isError }, { focused: isFocused })}
+        className={cx('text-field-text-group', { error: isError }, { focused: isFocused }, { 'non-label': !label })}
         role='textbox'
         tabIndex={0}
         onClick={handleClick}


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- TextField에서 라벨을 사용하지 않을때, focus될 시 border 컬러를 primary로 변경하였습니다.

## 설명

### 📌 기능
-

### 📌 UI
-

### 📌 Props
-

### 📌 사용하기
-

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 🎥 모션 영상

### 📸 디바이스별 스크린샷

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
