### PR TITLE
Feat[#138]: account 페이지 구현, inputValidation 수정, inputNames.ts 추가

### DIFF
--- a/src/components/AccountForm/AccountForm.module.scss
+++ b/src/components/AccountForm/AccountForm.module.scss
@@ -1,0 +1,183 @@
+%input-group-base {
+  @include column-flexbox(start, center, 0.4rem);
+
+  position: relative;
+  width: 100%;
+  padding: 3.2rem 0 1.2rem;
+
+  &::after {
+    content: '';
+
+    position: absolute;
+    bottom: 0;
+    left: 0;
+
+    width: 100%;
+    height: 0.1rem;
+
+    background-color: $black50;
+  }
+}
+
+%inner-group-base {
+  @include flexbox(between, start);
+
+  @include responsive(M) {
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+
+  width: 100%;
+}
+
+%input-field-base {
+  @include responsive(M) {
+    width: 100%;
+  }
+
+  width: 45rem;
+}
+
+%sm-btn-base {
+  width: 8.8rem;
+  margin-left: auto;
+  padding-top: 2.4rem;
+}
+
+.container {
+  width: 100%;
+  height: 100%;
+
+  .mypage {
+    @include responsive(M) {
+      max-width: 100%;
+      padding: 8.8rem 1.5rem 4.8rem;
+    }
+
+    max-width: 70.8rem;
+    margin: 0 auto;
+    padding: 13.4rem 0 22.8rem;
+
+    &-main-title {
+      @include text-style(20, $white, bold);
+
+      position: relative;
+      width: 100%;
+      padding-bottom: 0.8rem;
+
+      &::after {
+        content: '';
+
+        position: absolute;
+        bottom: 0;
+        left: 0;
+
+        width: 100%;
+        height: 0.1rem;
+
+        background-color: $white;
+      }
+    }
+
+    &-profile-group {
+      @include flexbox(between, start);
+
+      @include responsive(M) {
+        flex-direction: column;
+        gap: 1.6rem;
+      }
+
+      position: relative;
+      width: 100%;
+      padding: 2.4rem 0;
+
+      &::after {
+        content: '';
+
+        position: absolute;
+        bottom: 0;
+        left: 0;
+
+        width: 100%;
+        height: 0.1rem;
+
+        background-color: $black50;
+      }
+
+      .btn-outer-group {
+        @include flexbox(between);
+
+        @include responsive(M) {
+          align-self: center;
+          min-width: 34.5rem;
+        }
+
+        min-width: 45rem;
+
+        .image-form {
+          .fieldset {
+            @include flexbox($gap: 1.2rem);
+
+            .image-field {
+              display: none;
+            }
+          }
+        }
+      }
+    }
+
+    .profile-form {
+      .input-group {
+        @extend %input-group-base;
+
+        .inner-group {
+          @extend %inner-group-base;
+
+          .input-field {
+            @extend %input-field-base;
+          }
+        }
+      }
+
+      .btn-group {
+        .sm-btn {
+          @extend %sm-btn-base;
+
+          padding-bottom: 4.2rem;
+        }
+
+        .lg-btn {
+          padding-bottom: 4.2rem;
+        }
+      }
+    }
+
+    .password-form {
+      .input-group {
+        @extend %input-group-base;
+
+        .inner-group {
+          @extend %inner-group-base;
+
+          .input-field {
+            @extend %input-field-base;
+          }
+        }
+      }
+
+      .btn-group {
+        .sm-btn {
+          @extend %sm-btn-base;
+        }
+      }
+    }
+
+    .title {
+      @include text-style(16, $white);
+    }
+
+    .hidden {
+      display: none;
+    }
+  }
+}

--- a/src/components/AccountForm/AccountForm.module.scss
+++ b/src/components/AccountForm/AccountForm.module.scss
@@ -1,22 +1,9 @@
 %input-group-base {
   @include column-flexbox(start, center, 2.4rem);
 
-  position: relative;
   width: 100%;
   padding: 3.2rem 0;
-
-  &::after {
-    content: '';
-
-    position: absolute;
-    bottom: 0;
-    left: 0;
-
-    width: 100%;
-    height: 0.1rem;
-
-    background-color: $black50;
-  }
+  border-bottom: 0.1rem solid $black;
 }
 
 %inner-group-base {
@@ -56,27 +43,18 @@
 
     max-width: 70.8rem;
     margin: 0 auto;
-    padding: 13.4rem 0 22.8rem;
+    padding: 13.4rem 0 12rem;
 
     &-main-title {
       @include text-style(20, $white, bold);
 
-      position: relative;
+      @include responsive(M) {
+        @include text-style(18, $white, bold);
+      }
+
       width: 100%;
       padding-bottom: 0.8rem;
-
-      &::after {
-        content: '';
-
-        position: absolute;
-        bottom: 0;
-        left: 0;
-
-        width: 100%;
-        height: 0.1rem;
-
-        background-color: $white;
-      }
+      border-bottom: 0.1rem solid $white;
     }
 
     &-profile-group {

--- a/src/components/AccountForm/AccountForm.module.scss
+++ b/src/components/AccountForm/AccountForm.module.scss
@@ -65,22 +65,9 @@
         gap: 1.6rem;
       }
 
-      position: relative;
       width: 100%;
       padding: 2.4rem 0;
-
-      &::after {
-        content: '';
-
-        position: absolute;
-        bottom: 0;
-        left: 0;
-
-        width: 100%;
-        height: 0.1rem;
-
-        background-color: $black50;
-      }
+      border-bottom: 0.1rem solid $black50;
 
       .btn-outer-group {
         @include flexbox(between);

--- a/src/components/AccountForm/AccountForm.module.scss
+++ b/src/components/AccountForm/AccountForm.module.scss
@@ -1,9 +1,9 @@
 %input-group-base {
-  @include column-flexbox(start, center, 0.4rem);
+  @include column-flexbox(start, center, 2.4rem);
 
   position: relative;
   width: 100%;
-  padding: 3.2rem 0 1.2rem;
+  padding: 3.2rem 0;
 
   &::after {
     content: '';

--- a/src/components/AccountForm/index.tsx
+++ b/src/components/AccountForm/index.tsx
@@ -1,0 +1,250 @@
+import { ChangeEvent, useRef, useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import classNames from 'classnames/bind';
+import { FormProvider, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { ERROR_MESSAGE, INPUT_NAMES, REGEX } from '@/constants';
+
+import Avatar from '@/components/commons/Avatar';
+import { BaseButton } from '@/components/commons/buttons';
+import { InputField } from '@/components/commons/inputs';
+import { ConfirmModal, ModalButton } from '@/components/commons/modals';
+import { USER_DATA } from '@/constants/mockData/headerMockData';
+import useMultiState from '@/hooks/useMultiState';
+
+import styles from './AccountForm.module.scss';
+
+const cx = classNames.bind(styles);
+
+const { profileImageUrl, nickname, password, passwordConfirm, image } = INPUT_NAMES;
+
+const ImageSchema = z.object({
+  [image]: z.instanceof(File),
+});
+
+const ProfileSchema = z.object({
+  [profileImageUrl]: z.string().optional(),
+  [nickname]: z.string().min(1, { message: ERROR_MESSAGE.nickname.min }),
+});
+
+const PasswordSchema = z
+  .object({
+    [password]: z
+      .string()
+      .min(8, { message: ERROR_MESSAGE.password.min })
+      .regex(REGEX.password, ERROR_MESSAGE.password.regex),
+    [passwordConfirm]: z.string(),
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    path: [passwordConfirm],
+    message: ERROR_MESSAGE.password.refine,
+  });
+
+const AccountForm = () => {
+  const { multiState, toggleClick } = useMultiState(['resetConfirmModal', 'saveAlertModal']);
+  const [newImageUrl, setNewImageUrl] = useState(USER_DATA.profileImageUrl || '');
+  const fileInputRef = useRef(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const Profilemethods = useForm({
+    mode: 'all',
+    resolver: zodResolver(ProfileSchema),
+    defaultValues: {
+      [nickname]: USER_DATA.nickname,
+      [profileImageUrl]: USER_DATA.profileImageUrl,
+    },
+  });
+  const subMethods = useForm({
+    mode: 'all',
+    resolver: zodResolver(ImageSchema),
+  });
+  const passwordMethods = useForm({
+    mode: 'all',
+    resolver: zodResolver(PasswordSchema),
+  });
+
+  const { setValue: setFormValue } = Profilemethods;
+  const { register, setValue } = subMethods;
+
+  const handleAttach = () => {
+    if (fileInputRef.current !== null) {
+      const input = fileInputRef.current as HTMLInputElement;
+      input.click();
+    }
+  };
+
+  const handleChangeImage = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const imagePreviewUrl = URL.createObjectURL(file);
+      setNewImageUrl(imagePreviewUrl);
+      setValue(image, file);
+      setFormValue(profileImageUrl, imagePreviewUrl);
+      if (buttonRef.current) {
+        buttonRef.current.click();
+      }
+    }
+  };
+
+  const handleClickReset = () => {
+    setFormValue(profileImageUrl, '');
+    setValue(image, '');
+    setNewImageUrl('');
+    toggleClick('resetConfirmModal');
+  };
+
+  const onSubmit = (data: object) => {
+    console.log(data);
+    toggleClick('saveAlertModal');
+  };
+
+  const fileOnSubmit = (data: object) => {
+    console.log('fileOnSubmit', data);
+  };
+
+  return (
+    <>
+      <section className={cx('container')}>
+        <div className={cx('mypage')}>
+          <h2 className={cx('mypage-main-title')}>프로필 수정</h2>
+
+          <div className={cx('mypage-profile-group')}>
+            <h3 className={cx('title')}>프로필 이미지</h3>
+            <div className={cx('btn-outer-group')}>
+              <Avatar size='large' profileImageUrl={newImageUrl} />
+              <form onSubmit={subMethods.handleSubmit(fileOnSubmit)} className={cx('image-form')}>
+                <fieldset className={cx('fieldset')}>
+                  <legend>프로필 이미지 등록</legend>
+                  <input
+                    {...register(image)}
+                    ref={fileInputRef}
+                    className={cx('image-field')}
+                    type='file'
+                    accept='.jpg, .png, .jpeg,'
+                    onChange={handleChangeImage}
+                  />
+                  <button ref={buttonRef} />
+                  <BaseButton theme='ghost' size='medium' onClick={handleAttach}>
+                    파일 첨부
+                  </BaseButton>
+                  <BaseButton theme='ghost' size='medium' color='red' onClick={() => toggleClick('resetConfirmModal')}>
+                    초기화
+                  </BaseButton>
+                </fieldset>
+              </form>
+            </div>
+          </div>
+
+          <FormProvider {...Profilemethods}>
+            <form onSubmit={Profilemethods.handleSubmit(onSubmit)} className={cx('profile-form')}>
+              <fieldset>
+                <legend>닉네임 변경</legend>
+                <div className={cx('input-group')}>
+                  <div className={cx('hidden')}>
+                    <InputField name={profileImageUrl} />
+                  </div>
+                  <div className={cx('inner-group')}>
+                    <span className={cx('title')}>이메일</span>
+                    <div className={cx('input-field')}>
+                      <InputField name='email' type='email' placeholder={USER_DATA.email} isErrorVisible isDisabled />
+                    </div>
+                  </div>
+                  <div className={cx('inner-group')}>
+                    <span className={cx('title')}>닉네임</span>
+                    <div className={cx('input-field')}>
+                      <InputField name={nickname} isErrorVisible maxLength={10} />
+                    </div>
+                  </div>
+                </div>
+                <div className={cx('btn-group')}>
+                  <div className={cx('sm-btn', 'sm-hidden')}>
+                    <BaseButton type='submit' theme='fill' size='medium' color='purple'>
+                      저장
+                    </BaseButton>
+                  </div>
+                  <div className={cx('lg-btn', 'sm-only')}>
+                    <BaseButton type='submit' theme='fill' size='large' color='purple'>
+                      저장
+                    </BaseButton>
+                  </div>
+                </div>
+              </fieldset>
+            </form>
+          </FormProvider>
+
+          <FormProvider {...passwordMethods}>
+            <h2 className={cx('mypage-main-title')}>비밀번호 수정</h2>
+            <form className={cx('password-form')} onSubmit={passwordMethods.handleSubmit(onSubmit)}>
+              <fieldset className={cx('fieldset')}>
+                <legend>비밀번호 변경</legend>
+                <div className={cx('input-group')}>
+                  <div className={cx('inner-group')}>
+                    <span className={cx('title')}>비밀번호</span>
+                    <div className={cx('input-field')}>
+                      <InputField
+                        name={password}
+                        placeholder={ERROR_MESSAGE.password.placeholder}
+                        type={'password'}
+                        isErrorVisible
+                      />
+                    </div>
+                  </div>
+                  <div className={cx('inner-group')}>
+                    <span className={cx('title')}>비밀번호 확인</span>
+                    <div className={cx('input-field')}>
+                      <InputField
+                        name={passwordConfirm}
+                        type={'password'}
+                        placeholder={ERROR_MESSAGE.password.placeholder}
+                        isErrorVisible
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className={cx('btn-group')}>
+                  <div className={cx('sm-btn', 'sm-hidden')}>
+                    <BaseButton type='submit' theme='fill' size='medium' color='purple'>
+                      저장
+                    </BaseButton>
+                  </div>
+                  <div className={cx('sm-only')}>
+                    <BaseButton type='submit' theme='fill' size='large' color='purple'>
+                      저장
+                    </BaseButton>
+                  </div>
+                </div>
+              </fieldset>
+            </form>
+          </FormProvider>
+        </div>
+      </section>
+
+      <ConfirmModal
+        openModal={multiState.resetConfirmModal}
+        onClose={() => toggleClick('resetConfirmModal')}
+        state='ALEART'
+        title='프로필 이미지를 초기화하시겠습니까?'
+        renderButton={
+          <>
+            <ModalButton variant='warning' onClick={handleClickReset}>
+              초기화
+            </ModalButton>
+            <ModalButton onClick={() => toggleClick('resetConfirmModal')}>닫기</ModalButton>
+          </>
+        }
+        warning
+      />
+      <ConfirmModal
+        openModal={multiState.saveAlertModal}
+        onClose={() => toggleClick('saveAlertModal')}
+        state='CONFIRM'
+        title='정보가 저장되었습니다'
+        renderButton={<ModalButton onClick={() => toggleClick('saveAlertModal')}>확인</ModalButton>}
+      />
+    </>
+  );
+};
+
+export default AccountForm;

--- a/src/components/AccountForm/index.tsx
+++ b/src/components/AccountForm/index.tsx
@@ -48,7 +48,7 @@ const AccountForm = () => {
   const fileInputRef = useRef(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  const Profilemethods = useForm({
+  const profileMethods = useForm({
     mode: 'all',
     resolver: zodResolver(ProfileSchema),
     defaultValues: {
@@ -56,16 +56,18 @@ const AccountForm = () => {
       [profileImageUrl]: USER_DATA.profileImageUrl,
     },
   });
+
   const subMethods = useForm({
     mode: 'all',
     resolver: zodResolver(ImageSchema),
   });
+
   const passwordMethods = useForm({
     mode: 'all',
     resolver: zodResolver(PasswordSchema),
   });
 
-  const { setValue: setFormValue } = Profilemethods;
+  const { setValue: setFormValue } = profileMethods;
   const { register, setValue } = subMethods;
 
   const handleAttach = () => {
@@ -95,6 +97,14 @@ const AccountForm = () => {
     toggleClick('resetConfirmModal');
   };
 
+  const handleCloseReset = () => {
+    toggleClick('resetConfirmModal');
+  };
+
+  const handleCloseSave = () => {
+    toggleClick('saveAlertModal');
+  };
+
   const onSubmit = (data: object) => {
     console.log(data);
     toggleClick('saveAlertModal');
@@ -108,6 +118,7 @@ const AccountForm = () => {
     <>
       <section className={cx('container')}>
         <div className={cx('mypage')}>
+          <h1 className={cx('visually-hidden')}>계정 수정</h1>
           <h2 className={cx('mypage-main-title')}>프로필 수정</h2>
 
           <div className={cx('mypage-profile-group')}>
@@ -137,8 +148,8 @@ const AccountForm = () => {
             </div>
           </div>
 
-          <FormProvider {...Profilemethods}>
-            <form onSubmit={Profilemethods.handleSubmit(onSubmit)} className={cx('profile-form')}>
+          <FormProvider {...profileMethods}>
+            <form onSubmit={profileMethods.handleSubmit(onSubmit)} className={cx('profile-form')}>
               <fieldset>
                 <legend>닉네임 변경</legend>
                 <div className={cx('input-group')}>
@@ -223,7 +234,7 @@ const AccountForm = () => {
 
       <ConfirmModal
         openModal={multiState.resetConfirmModal}
-        onClose={() => toggleClick('resetConfirmModal')}
+        onClose={handleCloseReset}
         state='ALEART'
         title='프로필 이미지를 초기화하시겠습니까?'
         renderButton={
@@ -231,17 +242,17 @@ const AccountForm = () => {
             <ModalButton variant='warning' onClick={handleClickReset}>
               초기화
             </ModalButton>
-            <ModalButton onClick={() => toggleClick('resetConfirmModal')}>닫기</ModalButton>
+            <ModalButton onClick={handleCloseReset}>닫기</ModalButton>
           </>
         }
         warning
       />
       <ConfirmModal
         openModal={multiState.saveAlertModal}
-        onClose={() => toggleClick('saveAlertModal')}
+        onClose={handleCloseSave}
         state='CONFIRM'
         title='정보가 저장되었습니다'
-        renderButton={<ModalButton onClick={() => toggleClick('saveAlertModal')}>확인</ModalButton>}
+        renderButton={<ModalButton onClick={handleCloseSave}>확인</ModalButton>}
       />
     </>
   );

--- a/src/components/layout/header/Header/index.tsx
+++ b/src/components/layout/header/Header/index.tsx
@@ -13,7 +13,7 @@ import DrawerMenu from '@/components/layout/header/DrawerMenu';
 import HeaderProfile from '@/components/layout/header/HeaderProfile';
 import Menu from '@/components/layout/header/Menu';
 import UserMenu from '@/components/layout/header/UserMenu';
-import { alarmData, userData } from '@/constants/mockData/headerMockData';
+import { alarmData, USER_DATA } from '@/constants/mockData/headerMockData';
 import { useDeviceType } from '@/hooks/useDeviceType';
 import useTogglePopup from '@/hooks/useTogglePopup';
 
@@ -52,7 +52,7 @@ const Header = () => {
     togglePopup: handleHeaderProfileActivation,
   } = useTogglePopup();
 
-  const { email, nickname, profileImageUrl } = userData;
+  const { email, nickname, profileImageUrl } = USER_DATA;
   const { totalCount, notifications } = alarmData;
 
   useEffect(() => {

--- a/src/components/mypage/MypageContent/index.tsx
+++ b/src/components/mypage/MypageContent/index.tsx
@@ -6,7 +6,7 @@ import { MYPAGE_TAB_OPTIONS } from '@/constants';
 
 import ProfileSummary from '@/components/commons/ProfileSummary';
 import Tab from '@/components/commons/Tab';
-import { userData } from '@/constants/mockData/headerMockData';
+import { USER_DATA } from '@/constants/mockData/headerMockData';
 import { MY_ACTIVITIES, MY_RESERVATIONS } from '@/constants/mockData/profileSummaryMockData';
 
 import styles from './MypageContent.module.scss';
@@ -29,9 +29,9 @@ const MypageContent = () => {
   return (
     <div className={cx('container')}>
       <ProfileSummary
-        nickname={userData.nickname}
-        email={userData.email}
-        profileImageUrl={userData.profileImageUrl}
+        nickname={USER_DATA.nickname}
+        email={USER_DATA.email}
+        profileImageUrl={USER_DATA.profileImageUrl}
         recruitmentTotalCount={MY_ACTIVITIES.totalCount}
         reservationTotalCount={MY_RESERVATIONS.totalCount}
       />

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -17,3 +17,4 @@ export * from './tapOptions';
 export * from './filterOptions';
 export * from './sortOptions';
 export * from './inputValidation';
+export * from './inputNames';

--- a/src/constants/inputNames.ts
+++ b/src/constants/inputNames.ts
@@ -1,0 +1,7 @@
+export const INPUT_NAMES = {
+  profileImageUrl: 'profileImageUrl',
+  nickname: 'nickname',
+  password: 'password',
+  passwordConfirm: 'passwordConfirm',
+  image: 'image',
+};

--- a/src/constants/inputValidation.ts
+++ b/src/constants/inputValidation.ts
@@ -7,9 +7,11 @@ export const ERROR_MESSAGE = {
     min: '8자 이상 입력해주세요',
     regex: '영문과 숫자를 합해 8자이상 15자 이내로 입력해주세요',
     refine: '비밀번호가 일치하지 않습니다',
+    placeholder: '새 비밀번호를 입력해주세요',
   },
   nickname: {
     min: '10자 이내로 입력해주세요',
+    palceholder: '닉네임을 입력해주세요',
   },
   review: {
     min: '최소 5자 이상 입력해 주세요',

--- a/src/constants/mockData/headerMockData.ts
+++ b/src/constants/mockData/headerMockData.ts
@@ -1,8 +1,9 @@
-export const userData = {
+export const USER_DATA = {
   id: 0,
   email: 'test123@test.com',
   nickname: 'test123',
-  profileImageUrl: '',
+  profileImageUrl:
+    'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/profile_image/2-3_116_1710848730094.png',
   createdAt: '2024-03-15T14:21:31.180Z',
   updatedAt: '2024-03-15T14:21:31.180Z',
 };

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -1,0 +1,10 @@
+import AccountForm from '@/components/AccountForm';
+import Layout from '@/components/layout/Layout';
+
+const AccountPage = () => {
+  return <AccountForm />;
+};
+
+export default AccountPage;
+
+AccountPage.FullLayout = Layout;


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #138 
- close #138

## 유형

- [x] 기능 구현
- [x] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

## 설명
- Account 페이지 구현
- form에서 사용하는 input의 name들을 constants/inputNames.ts에 객체로 추가했습니다.
- headerMockData의 userData 객체 스네이크 케이스로 변경하면서, 참조하던 다른 파일도 수정했습니다.

### 📌 기능
- 프로필 이미지 첨부 및 초기화
- 프로필 폼에서 저장 버튼 클릭시 프로필이미지, 닉네임 전송
- 패스워드 폼에서 저장 버튼 클릭시 새 비밀번호 전송
- 필드별 스키마 유효성 검사
- 저장 버튼 클릭시 모달 on

### 📌 UI
- 모바일 반응형 구현

### 📌 기존 시안에서 변경된 부분
- 폼을 2개로 분리하여 버튼이 2개 생겼습니다.
- 버튼 색상을 보라색으로 변경하였습니다.

## 스크린샷
### 📸 디바이스별 스크린샷
![image](https://github.com/sprint-team3/GGF/assets/92169354/8ce97fc1-5793-4ee9-b53f-b6fb45c787e9)

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 🎥 모션 영상

https://github.com/sprint-team3/GGF/assets/92169354/8c5d7e73-9899-481a-87cf-ede943f6d199


## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

- `constants/inputNames.ts` 에 각자 폼에서 사용하시는 input name들 저장해서 관리하면 좋을 것 같습니다.
- form을 3개나 사용하는 페이지라 onSubmit 함수를 미리 넣어두는 게 편해서 console.log를 찍었습니다... 양해 바랍니다😂
