### PR TITLE
Hotfix: EmptyCard 높이 고정값으로 수정

### DIFF
--- a/src/components/layout/empty/EmptyCard/EmptyCard.module.scss
+++ b/src/components/layout/empty/EmptyCard/EmptyCard.module.scss
@@ -3,9 +3,8 @@
 
   @include text-style(14, $gray40);
 
-  flex-grow: 1;
-
   width: 100%;
+  height: 20rem;
 
   background-color: $black70;
   border: 0.1rem dashed $gray50;


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [X] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- EmptyCard 의 높이를 flex-grow에서 고정값 20rem으로 수정

## 설명

### 📌 기능
-

### 📌 UI
-

### 📌 Props
-

### 📌 사용하기
-

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 🎥 모션 영상

### 📸 디바이스별 스크린샷

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
