### PR TITLE
Feat[#98]: 마이페이지 - 등록한 게시글 탭 컨텐츠 구현

### DIFF
--- a/src/apis/activities.ts
+++ b/src/apis/activities.ts
@@ -4,7 +4,7 @@ import {
   REVIEWS_API,
   RESERVATIONS_API,
   IMAGE_API,
-  PAGE_SIZE,
+  DEFAULT_PAGE_SIZE,
   PAGE_METHOD,
 } from '@/constants';
 
@@ -17,7 +17,7 @@ const Activities = {
 
   getList: () =>
     instance.get(ACTIVITIES_API, {
-      params: { size: PAGE_SIZE, method: PAGE_METHOD },
+      params: { size: DEFAULT_PAGE_SIZE, method: PAGE_METHOD },
     }),
 
   getScheduleList: (activityId: number, year: string, month: string) =>
@@ -27,7 +27,7 @@ const Activities = {
 
   getReviewList: (activityId: number) =>
     instance.get(`${ACTIVITIES_API}/${activityId}${REVIEWS_API}`, {
-      params: { size: PAGE_SIZE },
+      params: { size: DEFAULT_PAGE_SIZE },
     }),
 
   create: (value: ActivityCreateBody) => instance.post(ACTIVITIES_API, value),

--- a/src/apis/myActivities.ts
+++ b/src/apis/myActivities.ts
@@ -3,7 +3,7 @@ import {
   RESERVATION_DASHBOARD_API,
   RESERVED_SCHEDULE_API,
   RESERVATIONS_API,
-  PAGE_SIZE,
+  DEFAULT_PAGE_SIZE,
 } from '@/constants';
 
 import { ReservationStatus, EditReservationStatusBody, MyActivitiesBody } from '@/types';
@@ -14,7 +14,7 @@ export const MyActivities = {
   getList: () =>
     instance.get(`${MY_ACTIVITIES_API}`, {
       params: {
-        size: PAGE_SIZE,
+        size: DEFAULT_PAGE_SIZE,
       },
     }),
 
@@ -36,7 +36,7 @@ export const MyActivities = {
   getHourlyReservationList: (activityId: number, scheduleId: number, status: ReservationStatus) =>
     instance.get(`${MY_ACTIVITIES_API}/${activityId}${RESERVATIONS_API}`, {
       params: {
-        size: PAGE_SIZE,
+        size: DEFAULT_PAGE_SIZE,
         scheduleId,
         status,
       },

--- a/src/apis/myNotifications.ts
+++ b/src/apis/myNotifications.ts
@@ -1,4 +1,4 @@
-import { MY_NOTIFICATIONS_API, PAGE_SIZE } from '@/constants';
+import { MY_NOTIFICATIONS_API, DEFAULT_PAGE_SIZE } from '@/constants';
 
 import instance from './axios';
 
@@ -6,7 +6,7 @@ export const MyNotifications = {
   get: () =>
     instance.get(MY_NOTIFICATIONS_API, {
       params: {
-        size: PAGE_SIZE,
+        size: DEFAULT_PAGE_SIZE,
       },
     }),
 

--- a/src/apis/myReservations.ts
+++ b/src/apis/myReservations.ts
@@ -1,4 +1,4 @@
-import { MY_RESERVATIONS_API, PAGE_SIZE, REVIEWS_API } from '@/constants';
+import { MY_RESERVATIONS_API, DEFAULT_PAGE_SIZE, REVIEWS_API } from '@/constants';
 
 import { CreateReviewParams, MyReservationsStatus } from '@/types';
 
@@ -8,7 +8,7 @@ export const MyReservations = {
   get: (status: MyReservationsStatus) =>
     instance.get(MY_RESERVATIONS_API, {
       params: {
-        size: PAGE_SIZE,
+        size: DEFAULT_PAGE_SIZE,
         status,
       },
     }),

--- a/src/components/commons/Pagination/index.tsx
+++ b/src/components/commons/Pagination/index.tsx
@@ -32,7 +32,7 @@ const Pagination = ({ totalCount, pageState, postPerPage, onClick }: PaginationP
   } = usePagination(totalCount, pageState, postPerPage, onClick);
 
   const isArrowActivated = currentPageGroupIndex !== pagesArray.length - 1;
-  const showPagination = !!totalCount && totalCount !== PAGE_SIZE;
+  const showPagination = !!totalCount && postPerPage !== PAGE_SIZE;
 
   return (
     showPagination && (

--- a/src/components/commons/Pagination/index.tsx
+++ b/src/components/commons/Pagination/index.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 import classNames from 'classnames/bind';
 
-import { PAGE_SIZE, SVGS } from '@/constants';
+import { DEFAULT_PAGE_SIZE, SVGS } from '@/constants';
 
 import usePagination from '@/hooks/usePagination';
 
@@ -32,7 +32,7 @@ const Pagination = ({ totalCount, pageState, postPerPage, onClick }: PaginationP
   } = usePagination(totalCount, pageState, postPerPage, onClick);
 
   const isArrowActivated = currentPageGroupIndex !== pagesArray.length - 1;
-  const showPagination = !!totalCount && postPerPage !== PAGE_SIZE;
+  const showPagination = !!totalCount && postPerPage !== DEFAULT_PAGE_SIZE;
 
   return (
     showPagination && (

--- a/src/components/mypage/MyPosts/MyPosts.module.scss
+++ b/src/components/mypage/MyPosts/MyPosts.module.scss
@@ -1,0 +1,33 @@
+.mypost-container {
+  @include column-flexbox(start, stretch, 2.4rem);
+}
+
+.selected-game {
+  @include flexbox(start, center, 0.8rem);
+
+  &-title {
+    @include text-style(18, $white);
+  }
+
+  &-count {
+    @include text-style(14, $primary, bold);
+  }
+}
+
+.card {
+  &-area {
+    @include column-flexbox(start, stretch, 1.6rem);
+  }
+
+  &-list {
+    @include column-flexbox(start, stretch, 1.2rem);
+  }
+}
+
+.filter-sort {
+  @include flexbox(between, center);
+}
+
+.dropdown {
+  width: 12rem;
+}

--- a/src/components/mypage/MyPosts/MyPosts.module.scss
+++ b/src/components/mypage/MyPosts/MyPosts.module.scss
@@ -2,6 +2,10 @@
   @include column-flexbox(start, stretch, 2.4rem);
 }
 
+.title-area {
+  @include flexbox(between, center);
+}
+
 .selected-game {
   @include flexbox(start, center, 0.8rem);
 
@@ -26,8 +30,11 @@
 
 .filter-sort {
   @include flexbox(between, center);
+
+  position: relative;
 }
 
 .dropdown {
+  flex-shrink: 0;
   width: 12rem;
 }

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -17,9 +17,9 @@ import useProcessedDataList from '@/hooks/useProcessedDataList';
 
 import { ActivityResponse, MyActivitiesResponse, Order, SortOption } from '@/types';
 
-const cx = classNames.bind(styles);
-
 import styles from './MyPosts.module.scss';
+
+const cx = classNames.bind(styles);
 
 const MockApiResponse: MyActivitiesResponse = {
   cursorId: 0,

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -64,10 +64,21 @@ const MyPosts = () => {
 
   return (
     <div className={cx('mypost-container')}>
-      <h2 className={cx('selected-game')}>
-        <span className={cx('selected-game-title')}>{formatCategoryToGameNameKR(selectFilter.category) ?? '전체'}</span>
-        <span className={cx('selected-game-count')}>{totalCount}</span>
-      </h2>
+      <div className={cx('title-area')}>
+        <h2 className={cx('selected-game')}>
+          <span className={cx('selected-game-title')}>
+            {formatCategoryToGameNameKR(selectFilter.category) ?? '전체'}
+          </span>
+          <span className={cx('selected-game-count')}>{totalCount}</span>
+        </h2>
+        <div className={cx('dropdown', 'sm-only')}>
+          <Dropdown
+            options={dropdownOptions}
+            onChange={(orderType) => setSortOption((prev) => ({ ...prev, order: orderType }))}
+            isSmall
+          />
+        </div>
+      </div>
       <div className={cx('card-area')}>
         <div className={cx('filter-sort')}>
           <Filter
@@ -75,7 +86,7 @@ const MyPosts = () => {
             selectedFilterId={selectFilter.category}
             onChange={(selectedId) => setSelectFilter({ category: selectedId })}
           />
-          <div className={cx('dropdown')}>
+          <div className={cx('dropdown', 'sm-hidden')}>
             <Dropdown
               options={dropdownOptions}
               onChange={(orderType) => setSortOption((prev) => ({ ...prev, order: orderType }))}

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+
+import classNames from 'classnames/bind';
+
+import { GAME_FILTERS, POSTS_PER_PAGE, PRICE_TO_POST_TYPES } from '@/constants';
+import { formatCategoryToGameNameKR } from '@/utils';
+
+import { RegisteredCard } from '@/components/commons/cards';
+import Dropdown from '@/components/commons/Dropdown';
+import Filter from '@/components/commons/Filter';
+import Pagination from '@/components/commons/Pagination';
+import MockActivityDatas from '@/constants/mockData/myActivitiesMockData.json';
+import useProcessedDataList from '@/hooks/useProcessedDataList';
+
+import { ActivityResponse, MyActivitiesResponse, Order, SortOption } from '@/types';
+
+const cx = classNames.bind(styles);
+
+import styles from './MyPosts.module.scss';
+
+const MockApiResponse: MyActivitiesResponse = {
+  cursorId: 0,
+  totalCount: 0,
+  activities: MockActivityDatas,
+};
+
+const initialFilter = {
+  category: GAME_FILTERS[0].id,
+};
+
+const initialSortOption: SortOption<ActivityResponse> = {
+  key: 'createdAt',
+  type: 'date',
+  order: 'desc',
+};
+
+const dropdownOptions: {
+  title: string;
+  orderType: Order;
+}[] = [
+  { title: '최신순', orderType: 'desc' },
+  { title: '오래된순', orderType: 'asc' },
+];
+
+const MyPosts = () => {
+  const [page, setPage] = useState(1);
+  const [selectFilter, setSelectFilter] = useState(initialFilter);
+  const [sortOption, setSortOption] = useState(initialSortOption);
+
+  const { pagedDataList, totalCount } = useProcessedDataList({
+    initialDataList: MockApiResponse.activities,
+    selectFilter,
+    sortOption,
+    page,
+    setPage,
+    postsPerPage: POSTS_PER_PAGE,
+  });
+
+  return (
+    <div className={cx('mypost-container')}>
+      <h2 className={cx('selected-game')}>
+        <span className={cx('selected-game-title')}>{formatCategoryToGameNameKR(selectFilter.category) ?? '전체'}</span>
+        <span className={cx('selected-game-count')}>{totalCount}</span>
+      </h2>
+      <div className={cx('card-area')}>
+        <div className={cx('filter-sort')}>
+          <Filter
+            items={GAME_FILTERS}
+            selectedFilterId={selectFilter.category}
+            onChange={(selectedId) => setSelectFilter({ category: selectedId })}
+          />
+          <div className={cx('dropdown')}>
+            <Dropdown
+              options={dropdownOptions}
+              onChange={(orderType) => setSortOption((prev) => ({ ...prev, order: orderType }))}
+              isSmall
+            />
+          </div>
+        </div>
+        <ul className={cx('card-list')}>
+          {pagedDataList.map((data) => (
+            <li key={data.id}>
+              <RegisteredCard
+                path={''}
+                postType={PRICE_TO_POST_TYPES[data.price]}
+                title={data.title}
+                address={data.address}
+                category={formatCategoryToGameNameKR(data.category)}
+                createdAt={data.createdAt}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+      <Pagination
+        totalCount={totalCount}
+        pageState={page}
+        postPerPage={POSTS_PER_PAGE}
+        onClick={(pageNumber) => setPage(pageNumber)}
+      />
+    </div>
+  );
+};
+
+export default MyPosts;

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -39,10 +39,10 @@ const initialSortOption: SortOption<ActivityResponse> = {
 
 const dropdownOptions: {
   title: string;
-  orderType: Order;
+  value: Order;
 }[] = [
-  { title: '최신순', orderType: 'desc' },
-  { title: '오래된순', orderType: 'asc' },
+  { title: '최신순', value: 'desc' },
+  { title: '오래된순', value: 'asc' },
 ];
 
 const MyPosts = () => {
@@ -74,7 +74,7 @@ const MyPosts = () => {
         <div className={cx('dropdown', 'sm-only')}>
           <Dropdown
             options={dropdownOptions}
-            onChange={(orderType) => setSortOption((prev) => ({ ...prev, order: orderType }))}
+            onChange={(value) => setSortOption((prev) => ({ ...prev, order: value as Order }))}
             isSmall
           />
         </div>
@@ -89,7 +89,7 @@ const MyPosts = () => {
           <div className={cx('dropdown', 'sm-hidden')}>
             <Dropdown
               options={dropdownOptions}
-              onChange={(orderType) => setSortOption((prev) => ({ ...prev, order: orderType }))}
+              onChange={(value) => setSortOption((prev) => ({ ...prev, order: value as Order }))}
               isSmall
             />
           </div>

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -53,10 +53,6 @@ const MyPosts = () => {
 
   const pageSize = getPostPageSize(currentDeviceType);
 
-  const handleClickPage = (pageNumber: number) => setPage(pageNumber);
-  const handleSelectFilter = (selectedId: string) => setSelectFilter({ category: selectedId });
-  const handleOptionChange = (value: string | number) => setSortOption((prev) => ({ ...prev, order: value as Order }));
-
   const { pagedDataList, totalCount } = useProcessedDataList({
     initialDataList: MockApiResponse.activities,
     selectFilter,
@@ -65,6 +61,10 @@ const MyPosts = () => {
     setPage,
     postsPerPage: pageSize,
   });
+
+  const handleClickPage = (pageNumber: number) => setPage(pageNumber);
+  const handleSelectFilter = (selectedId: string) => setSelectFilter({ category: selectedId });
+  const handleOptionChange = (value: string | number) => setSortOption((prev) => ({ ...prev, order: value as Order }));
 
   return (
     <div className={cx('mypost-container')}>

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 
 import classNames from 'classnames/bind';
 
-import { GAME_FILTERS, POSTS_PER_PAGE, PRICE_TO_POST_TYPES } from '@/constants';
+import { GAME_FILTERS, PRICE_TO_POST_TYPES } from '@/constants';
 import { formatCategoryToGameNameKR } from '@/utils';
+import { getPostPageSize } from '@/utils/getPageSize';
 
 import { RegisteredCard } from '@/components/commons/cards';
 import Dropdown from '@/components/commons/Dropdown';
@@ -11,6 +12,7 @@ import Filter from '@/components/commons/Filter';
 import Pagination from '@/components/commons/Pagination';
 import EmptyCard from '@/components/layout/empty/EmptyCard';
 import MockActivityDatas from '@/constants/mockData/myActivitiesMockData.json';
+import { useDeviceType } from '@/hooks/useDeviceType';
 import useProcessedDataList from '@/hooks/useProcessedDataList';
 
 import { ActivityResponse, MyActivitiesResponse, Order, SortOption } from '@/types';
@@ -47,6 +49,9 @@ const MyPosts = () => {
   const [page, setPage] = useState(1);
   const [selectFilter, setSelectFilter] = useState(initialFilter);
   const [sortOption, setSortOption] = useState(initialSortOption);
+  const currentDeviceType = useDeviceType();
+
+  const pageSize = getPostPageSize(currentDeviceType);
 
   const { pagedDataList, totalCount } = useProcessedDataList({
     initialDataList: MockApiResponse.activities,
@@ -54,7 +59,7 @@ const MyPosts = () => {
     sortOption,
     page,
     setPage,
-    postsPerPage: POSTS_PER_PAGE,
+    postsPerPage: pageSize,
   });
 
   return (
@@ -100,7 +105,7 @@ const MyPosts = () => {
       <Pagination
         totalCount={totalCount}
         pageState={page}
-        postPerPage={POSTS_PER_PAGE}
+        postPerPage={pageSize}
         onClick={(pageNumber) => setPage(pageNumber)}
       />
     </div>

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -53,6 +53,10 @@ const MyPosts = () => {
 
   const pageSize = getPostPageSize(currentDeviceType);
 
+  const handleClickPage = (pageNumber: number) => setPage(pageNumber);
+  const handleSelectFilter = (selectedId: string) => setSelectFilter({ category: selectedId });
+  const handleOptionChange = (value: string | number) => setSortOption((prev) => ({ ...prev, order: value as Order }));
+
   const { pagedDataList, totalCount } = useProcessedDataList({
     initialDataList: MockApiResponse.activities,
     selectFilter,
@@ -72,26 +76,14 @@ const MyPosts = () => {
           <span className={cx('selected-game-count')}>{totalCount}</span>
         </h2>
         <div className={cx('dropdown', 'sm-only')}>
-          <Dropdown
-            options={dropdownOptions}
-            onChange={(value) => setSortOption((prev) => ({ ...prev, order: value as Order }))}
-            isSmall
-          />
+          <Dropdown options={dropdownOptions} onChange={handleOptionChange} isSmall />
         </div>
       </div>
       <div className={cx('card-area')}>
         <div className={cx('filter-sort')}>
-          <Filter
-            items={GAME_FILTERS}
-            selectedFilterId={selectFilter.category}
-            onChange={(selectedId) => setSelectFilter({ category: selectedId })}
-          />
+          <Filter items={GAME_FILTERS} selectedFilterId={selectFilter.category} onChange={handleSelectFilter} />
           <div className={cx('dropdown', 'sm-hidden')}>
-            <Dropdown
-              options={dropdownOptions}
-              onChange={(value) => setSortOption((prev) => ({ ...prev, order: value as Order }))}
-              isSmall
-            />
+            <Dropdown options={dropdownOptions} onChange={handleOptionChange} isSmall />
           </div>
         </div>
         {totalCount ? (
@@ -113,12 +105,7 @@ const MyPosts = () => {
           <EmptyCard text='No Post' />
         )}
       </div>
-      <Pagination
-        totalCount={totalCount}
-        pageState={page}
-        postPerPage={pageSize}
-        onClick={(pageNumber) => setPage(pageNumber)}
-      />
+      <Pagination totalCount={totalCount} pageState={page} postPerPage={pageSize} onClick={handleClickPage} />
     </div>
   );
 };

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -9,6 +9,7 @@ import { RegisteredCard } from '@/components/commons/cards';
 import Dropdown from '@/components/commons/Dropdown';
 import Filter from '@/components/commons/Filter';
 import Pagination from '@/components/commons/Pagination';
+import EmptyCard from '@/components/layout/empty/EmptyCard';
 import MockActivityDatas from '@/constants/mockData/myActivitiesMockData.json';
 import useProcessedDataList from '@/hooks/useProcessedDataList';
 
@@ -77,20 +78,24 @@ const MyPosts = () => {
             />
           </div>
         </div>
-        <ul className={cx('card-list')}>
-          {pagedDataList.map((data) => (
-            <li key={data.id}>
-              <RegisteredCard
-                path={''}
-                postType={PRICE_TO_POST_TYPES[data.price]}
-                title={data.title}
-                address={data.address}
-                category={formatCategoryToGameNameKR(data.category)}
-                createdAt={data.createdAt}
-              />
-            </li>
-          ))}
-        </ul>
+        {totalCount ? (
+          <ul className={cx('card-list')}>
+            {pagedDataList.map((data) => (
+              <li key={data.id}>
+                <RegisteredCard
+                  path={''}
+                  postType={PRICE_TO_POST_TYPES[data.price]}
+                  title={data.title}
+                  address={data.address}
+                  category={formatCategoryToGameNameKR(data.category)}
+                  createdAt={data.createdAt}
+                />
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyCard text='No Post' />
+        )}
       </div>
       <Pagination
         totalCount={totalCount}

--- a/src/components/mypage/MypageContent/index.tsx
+++ b/src/components/mypage/MypageContent/index.tsx
@@ -6,6 +6,7 @@ import { MYPAGE_TAB_OPTIONS } from '@/constants';
 
 import ProfileSummary from '@/components/commons/ProfileSummary';
 import Tab from '@/components/commons/Tab';
+import MyPosts from '@/components/mypage/MyPosts';
 import { USER_DATA } from '@/constants/mockData/headerMockData';
 import { MY_ACTIVITIES, MY_RESERVATIONS } from '@/constants/mockData/profileSummaryMockData';
 
@@ -14,7 +15,7 @@ import styles from './MypageContent.module.scss';
 const cx = classNames.bind(styles);
 
 const tabContentMap: TabContent = {
-  myPost: <div>MyPostTabContent component here</div>,
+  myPost: <MyPosts />,
   myReservation: <div>ReservedTabContent component here</div>,
   reservationsStatus: <div>ReservationsStatusTabContent component here</div>,
 };

--- a/src/constants/paging.ts
+++ b/src/constants/paging.ts
@@ -1,4 +1,4 @@
-export const PAGE_SIZE = 1000;
+export const DEFAULT_PAGE_SIZE = 1000;
 
 export const PAGE_METHOD = 'offset';
 

--- a/src/constants/postTypes.ts
+++ b/src/constants/postTypes.ts
@@ -1,3 +1,5 @@
+import { PostTypes } from '@/types';
+
 export const POST_TYPES = {
   offline: '오프라인',
   online: '온라인',
@@ -5,7 +7,7 @@ export const POST_TYPES = {
   'game-strategy': '게임 공략',
 };
 
-export const PRICE_TO_POST_TYPES = {
+export const PRICE_TO_POST_TYPES: Record<number, PostTypes> = {
   0: 'offline',
   1: 'online',
   2: 'clan-recruitment',

--- a/src/hooks/usePaginatedDataList.ts
+++ b/src/hooks/usePaginatedDataList.ts
@@ -15,7 +15,7 @@ const usePaginatedDataList = <T>({ initialDataList, page, setPage, postsPerPage 
 
   useEffect(() => {
     setPage(1);
-  }, [initialDataList, setPage]);
+  }, [initialDataList, postsPerPage, setPage]);
 
   useEffect(() => {
     setPagedDataList(initialDataList.filter((data, index) => index >= startIndex && index < endIndex));

--- a/src/utils/getPageSize.ts
+++ b/src/utils/getPageSize.ts
@@ -1,0 +1,7 @@
+import { PAGE_SIZE, POSTS_PER_PAGE, REVIEWS_PER_PAGE } from '@/constants';
+
+import { DeviceType } from '@/types';
+
+export const getPostPageSize = (deviceType: DeviceType) => (deviceType === 'Mobile' ? PAGE_SIZE : POSTS_PER_PAGE);
+
+export const getReviewPageSize = (deviceType: DeviceType) => (deviceType === 'Mobile' ? PAGE_SIZE : REVIEWS_PER_PAGE);

--- a/src/utils/getPageSize.ts
+++ b/src/utils/getPageSize.ts
@@ -1,7 +1,9 @@
-import { PAGE_SIZE, POSTS_PER_PAGE, REVIEWS_PER_PAGE } from '@/constants';
+import { DEFAULT_PAGE_SIZE, POSTS_PER_PAGE, REVIEWS_PER_PAGE } from '@/constants';
 
 import { DeviceType } from '@/types';
 
-export const getPostPageSize = (deviceType: DeviceType) => (deviceType === 'Mobile' ? PAGE_SIZE : POSTS_PER_PAGE);
+export const getPostPageSize = (deviceType: DeviceType) =>
+  deviceType === 'Mobile' ? DEFAULT_PAGE_SIZE : POSTS_PER_PAGE;
 
-export const getReviewPageSize = (deviceType: DeviceType) => (deviceType === 'Mobile' ? PAGE_SIZE : REVIEWS_PER_PAGE);
+export const getReviewPageSize = (deviceType: DeviceType) =>
+  deviceType === 'Mobile' ? DEFAULT_PAGE_SIZE : REVIEWS_PER_PAGE;


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #98 
- close #98 

## 유형

- [X] 기능 구현
- [X] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 마이페이지 - 등록한 게시글 탭 컨텐츠 구현

## 설명

### 📌 기능
- 데이터 수정/삭제 등을 제외한 페이지 기능 구현
- [공용 기능] 디바이스 타입에 따라 페이지 사이즈를 초기화 해주는 유틸함수 추가 (게시글/리뷰)
- [공용 기능] usePaginatedDataList 훅에서 페이지 사이즈가 변경되면 활성화된 페이지를 1로 초기화하도록 수정
- [공용 기능] useFilteredDataList 훅에서 필터 키의 값이 'all' 일땐 해당 키에 대한 필터링을 하지 않도록 수정
- [공용 컴포넌트] Filter 컴포넌트의 이벤트 핸들러를 일반 화살표함수로 변경하고, 선택된 필터 ID를 인자로 받도록 수정

### 📌 UI
- 필터, 드롭다운, 카드, 페이징 컴포넌트를 조합해서 페이지 UI 작업 완료
- 모바일 사이즈 대응 완료


## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 🎥 모션 영상

https://github.com/sprint-team3/GGF/assets/43297823/f5e79031-caad-4025-9009-8b09e42d0177


### 📸 디바이스별 스크린샷

![image](https://github.com/sprint-team3/GGF/assets/43297823/f85aa0df-7abe-4bad-a584-219f9785c1d7)

![image](https://github.com/sprint-team3/GGF/assets/43297823/5c9260ee-48df-419b-a670-7fb36c2a9b8e)
