### PR TITLE
Hotfix: inputfield 실시간 글자수 구현

### DIFF
--- a/src/components/commons/inputs/InputField.module.scss
+++ b/src/components/commons/inputs/InputField.module.scss
@@ -72,7 +72,7 @@
 
     &-footer {
       position: absolute;
-      right: 1.2rem;
+      right: 1.6rem;
       bottom: 1.2rem;
 
       .current-num,

--- a/src/components/commons/inputs/InputField.module.scss
+++ b/src/components/commons/inputs/InputField.module.scss
@@ -44,6 +44,10 @@
         padding: 0 5.6rem 0 1.6rem;
       }
 
+      &.is-limited {
+        padding: 0 6.2rem 0 1.6rem;
+      }
+
       &:focus {
         border-color: $purple;
       }
@@ -64,6 +68,27 @@
       @include pos-center-y;
 
       right: 1.6rem;
+    }
+
+    &-footer {
+      position: absolute;
+      right: 1.2rem;
+      bottom: 1.2rem;
+
+      .current-num,
+      .total-num {
+        @include text-style(12, $gray50);
+      }
+
+      .current-num {
+        &.error {
+          color: $red;
+        }
+
+        &.active:not(.error) {
+          color: $gray10;
+        }
+      }
     }
   }
 

--- a/src/components/commons/inputs/InputField.tsx
+++ b/src/components/commons/inputs/InputField.tsx
@@ -14,10 +14,11 @@ type InputFieldProps = {
   label?: string;
   type?: 'text' | 'email' | 'password';
   isErrorVisible?: boolean;
+  isLimited?: boolean;
   isDisabled?: boolean;
-  placeholder?: string;
   maxLength?: number;
   minLength?: number;
+  placeholder?: string;
 };
 
 export const InputField = ({
@@ -25,17 +26,26 @@ export const InputField = ({
   label,
   type = 'text',
   isErrorVisible = false,
+  isLimited = false,
   isDisabled = false,
+  maxLength = 10,
+  minLength = 1,
   ...props
 }: InputFieldProps) => {
   const {
     register,
     formState: { errors },
+    watch,
   } = useFormContext();
+
   const isError = !!errors[name]?.message;
   const { isVisible, handleToggleClick } = useToggleButton();
   const { iconEye, inputType, showMode } = isVisible ? PASSWORD_SHOW_MODE.on : PASSWORD_SHOW_MODE.off;
   const isPassword = type === 'password';
+  const textLength = watch(name)?.length || 0;
+
+  const isBelowMinLength = textLength < minLength;
+  const isValidLength = textLength >= minLength;
 
   return (
     <div className={cx('input-field')}>
@@ -47,10 +57,17 @@ export const InputField = ({
           <input className={cx('input-field-input-group-input')} disabled {...props} />
         ) : (
           <input
-            className={cx('input-field-input-group-input', { error: isError }, { 'is-password': isPassword })}
+            className={cx(
+              'input-field-input-group-input',
+              { error: isError },
+              { 'is-password': isPassword },
+              { 'is-limited': isLimited && !isPassword },
+            )}
             type={type === 'password' ? inputType : type}
             autoComplete='on'
             {...register(name)}
+            maxLength={maxLength}
+            minLength={minLength}
             {...props}
           />
         )}
@@ -65,6 +82,14 @@ export const InputField = ({
           >
             <img src={iconEye} alt={showMode} />
           </button>
+        )}
+        {isLimited && !isPassword && (
+          <div className={cx('input-field-input-group-footer')}>
+            <span className={cx('current-num', { active: isValidLength }, { error: isBelowMinLength })}>
+              {textLength}
+            </span>
+            <span className={cx('total-num')}>/{maxLength}</span>
+          </div>
         )}
       </div>
       {isErrorVisible && !isDisabled && (


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [x] 기능 구현
- [x] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- Inputfield에도 실시간 글자수 기능을 적용했습니다.
- isLimited 프롭을 옵셔널로 추가하였습니다
- isLimited가 true이고 type이 password가 아닐 때 작동합니다.

## 설명

### 📌 추가된  Props
- isLimited : true면 실시간 글자수가 표시됩니다.
- maxLength와 minLength: 최대/최소 글자수로 isLimited를 사용할 떄는 필수로 넘겨주어야 합니다.


## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 🎥 모션 영상

### 📸 디바이스별 스크린샷
![image](https://github.com/sprint-team3/GGF/assets/92169354/33167006-7229-44f5-9074-309c7c492222)
![image](https://github.com/sprint-team3/GGF/assets/92169354/c4ce3840-c41f-4b6e-a2db-a8a06a1a7afa)

