### PR TITLE
Feat: 모집 상세 페이지의 ImageSlide, ImageModal 구현

### DIFF
--- a/src/components/postDetail/ImageModal/ImageModal.module.scss
+++ b/src/components/postDetail/ImageModal/ImageModal.module.scss
@@ -1,0 +1,33 @@
+.overlay {
+  @include flexbox;
+
+  position: fixed;
+  z-index: $overlay-level;
+  inset: 0;
+
+  width: 100%;
+  height: 100vh;
+
+  background-color: $opacity-black-50;
+}
+
+.image-modal {
+  @include flexbox;
+  @include thick-scrollbar;
+
+  cursor: pointer;
+  overflow-y: auto;
+  max-width: calc(100vh - 3.2rem);
+  transition: $base-transition;
+
+  &-img {
+    width: 100%;
+    height: 100%;
+
+    &-item {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
+  }
+}

--- a/src/components/postDetail/ImageModal/ImageModal.module.scss
+++ b/src/components/postDetail/ImageModal/ImageModal.module.scss
@@ -25,9 +25,7 @@
     height: 100%;
 
     &-item {
-      width: 100%;
-      height: 100%;
-      object-fit: contain;
+      @include image-fit(contain);
     }
   }
 }

--- a/src/components/postDetail/ImageModal/ImageModal.module.scss
+++ b/src/components/postDetail/ImageModal/ImageModal.module.scss
@@ -11,13 +11,21 @@
   background-color: $opacity-black-50;
 }
 
+.body-open {
+  overflow: hidden;
+}
+
 .image-modal {
   @include flexbox;
   @include thick-scrollbar;
 
   cursor: pointer;
+
   overflow-y: auto;
-  max-width: calc(100vh - 3.2rem);
+
+  max-width: 100%;
+  max-height: calc(100vh - 12.8rem);
+
   transition: $base-transition;
 
   &-img {

--- a/src/components/postDetail/ImageModal/index.tsx
+++ b/src/components/postDetail/ImageModal/index.tsx
@@ -21,6 +21,7 @@ const ImageModal = ({ isOpen, imageSrc, onClose }: ImageModalProps) => {
       shouldCloseOnEsc={true}
       className={cx('image-modal')}
       overlayClassName={cx('overlay')}
+      bodyOpenClassName={cx('body-open')}
       contentLabel='image-modal'
     >
       <div className={cx('image-modal-img')}>

--- a/src/components/postDetail/ImageModal/index.tsx
+++ b/src/components/postDetail/ImageModal/index.tsx
@@ -1,0 +1,33 @@
+import { MouseEventHandler } from 'react';
+
+import classNames from 'classnames/bind';
+import ReactModal from 'react-modal';
+
+import styles from './ImageModal.module.scss';
+
+const cx = classNames.bind(styles);
+
+type ImageModalProps = {
+  isOpen: boolean;
+  imageSrc: string;
+  onClose: MouseEventHandler<HTMLButtonElement>;
+};
+
+const ImageModal = ({ isOpen, imageSrc, onClose }: ImageModalProps) => {
+  return (
+    <ReactModal
+      isOpen={isOpen}
+      onRequestClose={onClose}
+      shouldCloseOnEsc={true}
+      className={cx('image-modal')}
+      overlayClassName={cx('overlay')}
+      contentLabel='image-modal'
+    >
+      <div className={cx('image-modal-img')}>
+        <img className={cx('image-modal-img-item')} src={imageSrc} alt='이미지 확대' />
+      </div>
+    </ReactModal>
+  );
+};
+
+export default ImageModal;

--- a/src/components/postDetail/ImageSlide/ImageSlide.module.scss
+++ b/src/components/postDetail/ImageSlide/ImageSlide.module.scss
@@ -11,9 +11,6 @@
   border-radius: 0.4rem;
 }
 
-$container-width: 100vw;
-$mobile-image-width: 70vw;
-
 .image-slide {
   position: relative;
 
@@ -33,23 +30,27 @@ $mobile-image-width: 70vw;
     @include slide-scrollbar;
 
     @include responsive(T) {
-      max-width: $container-width;
+      max-width: $slider-container-width;
     }
 
     @include responsive(M) {
       @include no-scrollbar;
 
-      max-width: calc($container-width - 1.5rem);
+      max-width: calc($slider-container-width - 1.5rem);
       padding-left: 1.5rem;
     }
 
+    scroll-behavior: smooth;
+
     overflow: scroll hidden;
+
     width: 112rem;
     height: 37.6rem;
+
     white-space: nowrap;
 
     &::-webkit-scrollbar-button {
-      width: calc($container-width * 0.3);
+      width: calc($slider-container-width * 0.3);
     }
 
     &-slider {

--- a/src/components/postDetail/ImageSlide/ImageSlide.module.scss
+++ b/src/components/postDetail/ImageSlide/ImageSlide.module.scss
@@ -1,6 +1,8 @@
 %btn-base {
   @include pos-center-y;
 
+  width: 4rem;
+  height: 4rem;
   padding: 1rem;
 
   background: $opacity-white-10;
@@ -9,12 +11,11 @@
   border-radius: 0.4rem;
 }
 
-$container-width: calc(100vw - 1.5rem);
+$container-width: 100vw;
 $mobile-image-width: 70vw;
 
 .image-slide {
   position: relative;
-  margin-left: 1.5rem;
 
   &-left-btn {
     @extend %btn-base;
@@ -37,6 +38,9 @@ $mobile-image-width: 70vw;
 
     @include responsive(M) {
       @include no-scrollbar;
+
+      max-width: calc($container-width - 1.5rem);
+      padding-left: 1.5rem;
     }
 
     overflow: scroll hidden;
@@ -49,14 +53,12 @@ $mobile-image-width: 70vw;
     }
 
     &-slider {
-      @include flexbox(start, center, 2rem);
-
       display: inline-block;
       min-width: 112rem;
       height: 37.6rem;
       padding-bottom: 1.2rem;
 
-      &-btn {
+      &-banner {
         @include responsive(M) {
           width: $mobile-image-width;
 
@@ -74,9 +76,7 @@ $mobile-image-width: 70vw;
         }
 
         .image {
-          width: 100%;
-          height: 100%;
-          object-fit: cover;
+          @include image-fit;
         }
       }
     }

--- a/src/components/postDetail/ImageSlide/ImageSlide.module.scss
+++ b/src/components/postDetail/ImageSlide/ImageSlide.module.scss
@@ -1,0 +1,93 @@
+%btn-base {
+  @include pos-center-y;
+
+  padding: 1rem;
+
+  background: $opacity-white-10;
+  backdrop-filter: $popup-blur;
+  border: 0.1rem solid $opacity-white-20;
+  border-radius: 0.4rem;
+}
+
+$container-width: calc(100vw - 1.5rem);
+$mobile-image-width: 70vw;
+
+.image-slide {
+  position: relative;
+  margin-left: 1.5rem;
+
+  &-left-btn {
+    @extend %btn-base;
+
+    left: -2rem;
+  }
+
+  &-right-btn {
+    @extend %btn-base;
+
+    right: -2rem;
+  }
+
+  &-container {
+    @include slide-scrollbar;
+
+    @include responsive(T) {
+      max-width: $container-width;
+    }
+
+    @include responsive(M) {
+      @include no-scrollbar;
+    }
+
+    overflow: scroll hidden;
+    width: 112rem;
+    height: 37.6rem;
+    white-space: nowrap;
+
+    &::-webkit-scrollbar-button {
+      width: calc($container-width * 0.3);
+    }
+
+    &-img-container {
+      &-slider {
+        @include flexbox(start, center, 2rem);
+
+        @include responsive(M) {
+          display: inline-block;
+        }
+
+        display: inline-block;
+        min-width: 112rem;
+        height: 37.6rem;
+        padding-bottom: 1.2rem;
+
+        &-btn {
+          @include responsive(M) {
+            overflow: hidden;
+            width: 93rem;
+            width: $mobile-image-width;
+            height: 36rem;
+
+            &:not(:last-child) {
+              margin-right: 1.5rem;
+            }
+          }
+
+          overflow: hidden;
+          width: 93rem;
+          height: 36rem;
+
+          &:not(:last-child) {
+            margin-right: 2rem;
+          }
+
+          .image {
+            width: 100%;
+            height: 36rem;
+            object-fit: cover;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/postDetail/ImageSlide/ImageSlide.module.scss
+++ b/src/components/postDetail/ImageSlide/ImageSlide.module.scss
@@ -28,7 +28,7 @@ $mobile-image-width: 70vw;
     right: -2rem;
   }
 
-  &-container {
+  .container {
     @include slide-scrollbar;
 
     @include responsive(T) {
@@ -48,44 +48,35 @@ $mobile-image-width: 70vw;
       width: calc($container-width * 0.3);
     }
 
-    &-img-container {
-      &-slider {
-        @include flexbox(start, center, 2rem);
+    &-slider {
+      @include flexbox(start, center, 2rem);
 
+      display: inline-block;
+      min-width: 112rem;
+      height: 37.6rem;
+      padding-bottom: 1.2rem;
+
+      &-btn {
         @include responsive(M) {
-          display: inline-block;
-        }
-
-        display: inline-block;
-        min-width: 112rem;
-        height: 37.6rem;
-        padding-bottom: 1.2rem;
-
-        &-btn {
-          @include responsive(M) {
-            overflow: hidden;
-            width: 93rem;
-            width: $mobile-image-width;
-            height: 36rem;
-
-            &:not(:last-child) {
-              margin-right: 1.5rem;
-            }
-          }
-
-          overflow: hidden;
-          width: 93rem;
-          height: 36rem;
+          width: $mobile-image-width;
 
           &:not(:last-child) {
-            margin-right: 2rem;
+            margin-right: 1.5rem;
           }
+        }
 
-          .image {
-            width: 100%;
-            height: 36rem;
-            object-fit: cover;
-          }
+        overflow: hidden;
+        width: 93rem;
+        height: 36rem;
+
+        &:not(:last-child) {
+          margin-right: 2rem;
+        }
+
+        .image {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
         }
       }
     }

--- a/src/components/postDetail/ImageSlide/index.tsx
+++ b/src/components/postDetail/ImageSlide/index.tsx
@@ -15,16 +15,16 @@ import styles from './ImageSlide.module.scss';
 const cx = classNames.bind(styles);
 
 const { leftArrow, rightArrow } = SVGS.button;
-const SCROLL_WIDTH = 945;
+const SCROLL_WIDTH = 950;
 
 type ImageSlideProps = {
   imageList?: string[];
 };
 
 const ImageSlide = ({ imageList = IMAGE_LIST }: ImageSlideProps) => {
-  const { isVisible, handleToggleClick } = useToggleButton();
   const [selectedImageSrc, setSelectedImageSrc] = useState('');
   const ref = useRef<HTMLDivElement>(null);
+  const { isVisible, handleToggleClick } = useToggleButton();
 
   const handleClickPrev = () => {
     if (ref.current) {
@@ -43,8 +43,6 @@ const ImageSlide = ({ imageList = IMAGE_LIST }: ImageSlideProps) => {
     handleToggleClick();
   };
 
-  const handleCloseModal = () => handleToggleClick();
-
   return (
     <div className={cx('image-slide')}>
       <button className={cx('image-slide-right-btn', 'sm-hidden')} onClick={handleClickPrev}>
@@ -57,16 +55,16 @@ const ImageSlide = ({ imageList = IMAGE_LIST }: ImageSlideProps) => {
         <div className={cx('container-slider')}>
           {imageList.map((item, index) => (
             <button
-              className={cx('container-slider-btn')}
+              className={cx('container-slider-banner')}
               key={`image-slide-${index}`}
               onClick={() => handleImageClick(index)}
             >
-              <img className={cx('image')} src={item} alt={`${item}`} />
+              <img className={cx('image')} src={item} alt={`배너 이미지-${index}`} />
             </button>
           ))}
         </div>
       </div>
-      <ImageModal imageSrc={selectedImageSrc} isOpen={isVisible} onClose={handleCloseModal} />
+      <ImageModal imageSrc={selectedImageSrc} isOpen={isVisible} onClose={handleToggleClick} />
     </div>
   );
 };

--- a/src/components/postDetail/ImageSlide/index.tsx
+++ b/src/components/postDetail/ImageSlide/index.tsx
@@ -1,0 +1,75 @@
+import Image from 'next/image';
+
+import { useRef, useState } from 'react';
+
+import classNames from 'classnames/bind';
+
+import { SVGS } from '@/constants';
+
+import ImageModal from '@/components/postDetail/ImageModal';
+import { IMAGE_LIST } from '@/constants/mockData/imageList';
+import useToggleButton from '@/hooks/useToggleButton';
+
+import styles from './ImageSlide.module.scss';
+
+const cx = classNames.bind(styles);
+
+const { leftArrow, rightArrow } = SVGS.button;
+
+type ImageSlideProps = {
+  imageList?: string[];
+};
+
+const ImageSlide = ({ imageList = IMAGE_LIST }: ImageSlideProps) => {
+  const { isVisible, handleToggleClick } = useToggleButton();
+  const [selectedImageSrc, setSelectedImageSrc] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleClickPrev = () => {
+    if (ref.current) {
+      ref.current.scrollLeft += 945;
+    }
+  };
+
+  const handleClickNext = () => {
+    if (ref.current) {
+      ref.current.scrollLeft += -945;
+    }
+  };
+
+  const handleImageClick = (index: number) => {
+    setSelectedImageSrc(imageList[index]);
+    handleToggleClick();
+  };
+
+  const handleCloseModal = () => handleToggleClick();
+
+  return (
+    <div className={cx('image-slide')}>
+      <button className={cx('image-slide-right-btn', 'sm-hidden')} onClick={handleClickPrev}>
+        <Image src={rightArrow.url} alt={rightArrow.alt} width={20} height={20} />
+      </button>
+      <button className={cx('image-slide-left-btn', 'sm-hidden')} onClick={handleClickNext}>
+        <Image src={leftArrow.url} alt={leftArrow.alt} width={20} height={20} />
+      </button>
+      <div className={cx('image-slide-container')} ref={ref}>
+        <div className={cx('image-slide-container-img-container')}>
+          <div className={cx('image-slide-container-img-container-slider')}>
+            {imageList.map((item, index) => (
+              <button
+                className={cx('image-slide-container-img-container-slider-btn')}
+                key={`image-slide-${index}`}
+                onClick={() => handleImageClick(index)}
+              >
+                <img className={cx('image')} src={item} alt={`${item}`} />
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      <ImageModal imageSrc={selectedImageSrc} isOpen={isVisible} onClose={handleCloseModal} />
+    </div>
+  );
+};
+
+export default ImageSlide;

--- a/src/components/postDetail/ImageSlide/index.tsx
+++ b/src/components/postDetail/ImageSlide/index.tsx
@@ -15,6 +15,7 @@ import styles from './ImageSlide.module.scss';
 const cx = classNames.bind(styles);
 
 const { leftArrow, rightArrow } = SVGS.button;
+const SCROLL_WIDTH = 945;
 
 type ImageSlideProps = {
   imageList?: string[];
@@ -27,13 +28,13 @@ const ImageSlide = ({ imageList = IMAGE_LIST }: ImageSlideProps) => {
 
   const handleClickPrev = () => {
     if (ref.current) {
-      ref.current.scrollLeft += 945;
+      ref.current.scrollLeft += SCROLL_WIDTH;
     }
   };
 
   const handleClickNext = () => {
     if (ref.current) {
-      ref.current.scrollLeft += -945;
+      ref.current.scrollLeft += -SCROLL_WIDTH;
     }
   };
 
@@ -52,19 +53,17 @@ const ImageSlide = ({ imageList = IMAGE_LIST }: ImageSlideProps) => {
       <button className={cx('image-slide-left-btn', 'sm-hidden')} onClick={handleClickNext}>
         <Image src={leftArrow.url} alt={leftArrow.alt} width={20} height={20} />
       </button>
-      <div className={cx('image-slide-container')} ref={ref}>
-        <div className={cx('image-slide-container-img-container')}>
-          <div className={cx('image-slide-container-img-container-slider')}>
-            {imageList.map((item, index) => (
-              <button
-                className={cx('image-slide-container-img-container-slider-btn')}
-                key={`image-slide-${index}`}
-                onClick={() => handleImageClick(index)}
-              >
-                <img className={cx('image')} src={item} alt={`${item}`} />
-              </button>
-            ))}
-          </div>
+      <div className={cx('container')} ref={ref}>
+        <div className={cx('container-slider')}>
+          {imageList.map((item, index) => (
+            <button
+              className={cx('container-slider-btn')}
+              key={`image-slide-${index}`}
+              onClick={() => handleImageClick(index)}
+            >
+              <img className={cx('image')} src={item} alt={`${item}`} />
+            </button>
+          ))}
         </div>
       </div>
       <ImageModal imageSrc={selectedImageSrc} isOpen={isVisible} onClose={handleCloseModal} />

--- a/src/constants/mockData/imageList.ts
+++ b/src/constants/mockData/imageList.ts
@@ -1,0 +1,7 @@
+export const IMAGE_LIST = [
+  '/pngs/banner-BG.png',
+  '/pngs/banner-BG.png',
+  '/pngs/banner-LOL.png',
+  '/pngs/banner-MC.png',
+  '/pngs/banner-OW.png',
+];

--- a/src/stories/ImageModal.stories.ts
+++ b/src/stories/ImageModal.stories.ts
@@ -1,0 +1,19 @@
+import ImageModal from '@/components/postDetail/ImageModal';
+import { IMAGE_LIST } from '@/constants/mockData/imageList';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'PostDetail/ImageModal',
+  component: ImageModal,
+} satisfies Meta<typeof ImageModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Example: Story = {
+  args: {
+    isOpen: true,
+    imageSrc: IMAGE_LIST[0],
+  },
+};

--- a/src/stories/ImageSlide.stories.ts
+++ b/src/stories/ImageSlide.stories.ts
@@ -1,0 +1,15 @@
+import ImageSlide from '@/components/postDetail/ImageSlide';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'PostDetail/ImageSlide',
+  component: ImageSlide,
+} satisfies Meta<typeof ImageSlide>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Example: Story = {
+  args: {},
+};

--- a/src/styles/mixins/_scrollbar.scss
+++ b/src/styles/mixins/_scrollbar.scss
@@ -48,3 +48,23 @@
     background-color: $black80;
   }
 }
+
+@mixin slide-scrollbar() {
+  &::-webkit-scrollbar-thumb {
+    background-color: $gray30;
+    border-radius: 1rem;
+  }
+
+  &::-webkit-scrollbar {
+    height: 0.4rem;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: $opacity-white-10;
+    border-radius: 1rem;
+  }
+
+  &::-webkit-scrollbar-button {
+    width: 43rem;
+  }
+}

--- a/src/styles/variables/_responsive-height.scss
+++ b/src/styles/variables/_responsive-height.scss
@@ -1,2 +1,4 @@
 $pc-header-height: 6.2rem;
 $mobile-header-height: 5.6rem;
+$slider-container-width: 100vw;
+$mobile-image-width: 70vw;


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #173 
- close #

## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 

## 설명

### 📌 기능
- 이미지 주소가 있는 배열을 prop으로 받아 슬라이드를 보여줍니다.
- 좌우 버튼 클릭시, 하단 스크롤바 클릭시 슬라이드가 이동합니다.
- 슬라이드 내의 이미지 클릭시 이미지가 들어있는 모달이 보여집니다.
- 모달의 overlay 클릭시 모달이 닫힙니다.

### 📌 UI
- viewport의 크기가 줄어도, 사진의 고정 width는 줄지 않고, 컨테이너의 크기만 줄어듭니다.
- 태블릿, 모바일 반응형 구현했습니다. 모바일일 때 컨테이너 왼쪽에 1.5rem 만큼 마진 생깁니다.

### 📌 Props
#### ImageSlide
1. `imageList?: string[];` : 이미지 주소가 들어있는 배열입ㅂ니다.

#### ImageModal
1. `isOpen: boolean;` : 모달의 열림상태를 나타냅니다.
2. `imageSrc: string;` : 모달에서 보여줄 image의 src입니다.
3. `onClose: MouseEventHandler<HTMLButtonElement>;` : 모달의 overlay 클릭시 모달의 열림상태를 false로 바꿔줄 함수입니다.

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 🎥 모션 영상

https://github.com/sprint-team3/GGF/assets/92169354/f2800edf-27f5-4688-b3bd-ecddcc6e7542


### 📸 디바이스별 스크린샷
![image](https://github.com/sprint-team3/GGF/assets/92169354/0f9e1a4c-5537-44d2-a9cc-a41efdf336a5)

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
