### PR TITLE
Hotfix: ImageField 업로드 버튼 transition 추가, label 추가, x 버튼 버그 수정

### DIFF
--- a/src/components/commons/inputs/ImageField.module.scss
+++ b/src/components/commons/inputs/ImageField.module.scss
@@ -61,12 +61,6 @@
             @include text-style(10, $gray30, light);
           }
         }
-
-        .upload-btn {
-          &:hover {
-            transition: $base-transition;
-          }
-        }
       }
     }
   }

--- a/src/components/commons/inputs/ImageField.module.scss
+++ b/src/components/commons/inputs/ImageField.module.scss
@@ -1,50 +1,71 @@
 .image-field {
-  @include column-flexbox($gap: 1.6rem);
+  @include column-flexbox(center, start, 0.8rem);
 
-  width: 100%;
+  &-label {
+    @include text-style(14, $white);
+  }
 
-  &-group {
+  &-container {
     @include column-flexbox;
 
     width: 100%;
-    height: 12rem;
 
-    background: $input-background;
-    border: 0.1rem dashed $input-stroke;
-    border-radius: 0.8rem;
-
-    &-title {
-      @include text-style(14, $gray40);
-
-      &.active {
-        color: $purple;
-      }
-    }
-  }
-
-  &-name-list {
-    @include column-flexbox(center, start, 0.8rem);
-
-    width: 100%;
-    margin-right: auto;
-
-    &-item {
-      @include flexbox(between);
+    &-group {
+      @include column-flexbox;
 
       width: 100%;
-      padding-bottom: 0.8rem;
-      border-bottom: 0.1rem solid $black60;
+      height: 12rem;
 
-      .item-group {
-        @include flexbox($gap: 0.8rem);
+      background: $input-background;
+      border: 0.1rem dashed $input-stroke;
+      border-radius: 0.8rem;
 
-        .image-group {
-          @include flexbox($gap: 0.2rem);
-          @include text-style(12, $gray10);
+      transition: $base-transition;
+
+      &:hover {
+        opacity: 0.5;
+      }
+
+      &-title {
+        @include text-style(14, $gray40);
+
+        &.active {
+          color: $purple;
+        }
+      }
+    }
+
+    &-name-list {
+      @include column-flexbox(center, start, 0.8rem);
+
+      width: 100%;
+      margin-right: auto;
+      padding-top: 1.2rem;
+
+      &-item {
+        @include flexbox(between);
+
+        width: 100%;
+        padding-bottom: 0.8rem;
+        border-bottom: 0.1rem solid $black60;
+
+        .item-group {
+          @include flexbox($gap: 0.8rem);
+
+          .image-group {
+            @include flexbox($gap: 0.2rem);
+            @include text-style(12, $gray10);
+          }
+
+          .file-size {
+            @include text-style(10, $gray30, light);
+          }
         }
 
-        .file-size {
-          @include text-style(10, $gray30, light);
+        .upload-btn {
+          &:hover {
+            transition: $base-transition;
+          }
         }
       }
     }

--- a/src/components/commons/inputs/ImageField.module.scss
+++ b/src/components/commons/inputs/ImageField.module.scss
@@ -23,7 +23,8 @@
       transition: $base-transition;
 
       &:hover {
-        opacity: 0.5;
+        background: $black80;
+        border-color: $purple;
       }
 
       &-title {

--- a/src/components/commons/inputs/ImageField.tsx
+++ b/src/components/commons/inputs/ImageField.tsx
@@ -30,9 +30,10 @@ type ImageFiledProps = {
 };
 
 export const ImageField = ({ label, onFilesUpdate }: ImageFiledProps) => {
-  const { multiState, toggleClick } = useMultiState(['fileExceededModal']);
   const [files, setFiles] = useState<{ file: File; isCloseActive: boolean }[]>([]);
   const [finalFiles, setFinalFiles] = useState<File[]>([]);
+
+  const { multiState, toggleClick } = useMultiState(['fileExceededModal', 'isUploadActive']);
 
   const onDrop = useCallback((uploadedFiles: File[]) => {
     const newFiles = uploadedFiles.map((file) => ({ file, isCloseActive: false }));
@@ -69,6 +70,8 @@ export const ImageField = ({ label, onFilesUpdate }: ImageFiledProps) => {
     setFinalFiles(filteredFiles);
   };
 
+  const handleMouseEvent = () => toggleClick('isUploadActive');
+
   const handleMouseEnter = (buttonIndex: number) =>
     setFiles((prevFiles) =>
       prevFiles.map((item, index) => (index === buttonIndex ? { ...item, isCloseActive: true } : item)),
@@ -87,8 +90,8 @@ export const ImageField = ({ label, onFilesUpdate }: ImageFiledProps) => {
       <div className={cx('image-field-container')}>
         <button
           className={cx('image-field-container-group')}
-          onMouseEnter={() => toggleClick('isUploadActive')}
-          onMouseLeave={() => toggleClick('isUploadActive')}
+          onMouseEnter={handleMouseEvent}
+          onMouseLeave={handleMouseEvent}
           {...getRootProps()}
         >
           <input className={cx('image-field-container-group-input')} {...getInputProps()} />
@@ -118,14 +121,12 @@ export const ImageField = ({ label, onFilesUpdate }: ImageFiledProps) => {
                 <span className={cx('file-size')}>{bytesToKilobytes(item?.file?.size)}KB</span>
               </div>
               <button
-                className={cx('upload-btn')}
                 value={index}
                 onClick={(event) => handleDelete(event.currentTarget.value)}
                 onMouseEnter={() => handleMouseEnter(index)}
                 onMouseLeave={() => handleMouseLeave(index)}
               >
                 <Image
-                  className={cx('upload-btn')}
                   src={item.isCloseActive ? closeActiveUrl : closeDefaultUrl}
                   alt={item.isCloseActive ? closeActiveAlt : closeDefaultAlt}
                   width={16}
@@ -142,7 +143,7 @@ export const ImageField = ({ label, onFilesUpdate }: ImageFiledProps) => {
         onClose={handleClickModal}
         title='파일 초과'
         state='ALERT'
-        desc='이미지는 5장까지 업로드할 수 있습니다'
+        desc='이미지는 5개까지 업로드할 수 있습니다'
         warning
         renderButton={
           <ModalButton variant='warning' onClick={handleClickModal}>

--- a/src/stories/ImageField.stories.ts
+++ b/src/stories/ImageField.stories.ts
@@ -10,4 +10,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Example: Story = {};
+export const Example: Story = {
+  args: {
+    label: '테스트',
+  },
+};


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

## 설명

### 📌 기능
- 파일 새로 첨부시 기존 리스트 다 삭제하도록 했습니다.
- 이미지 하나 x 버튼으로 삭제시, hover 효과 오작동 해결했습니다.
- 이미지 첨부된 파일 리스트가 변경될 때마다 `onFilesUpdate`로 전달되도록 했습니다.

### 📌 UI
- 이미지 첨부없을 때 보이는` flex-gap` 삭제하고, list에 `padding-top` `1.6rem` 추가했습니다.
- drag 아이콘에 `opacity transition` 적용했습니다.
- 라벨 추가했습니다.

### 📌 Props
- `label: string` 추가했습니다.

### 시연 영상

https://github.com/sprint-team3/GGF/assets/92169354/41ca1121-648e-4307-ba2c-67c9ef63f1cb

