### PR TITLE
Hotfix: Datefield css수정, 30일 제한 날짜선택 추가

### DIFF
--- a/src/components/commons/inputs/DateField.module.scss
+++ b/src/components/commons/inputs/DateField.module.scss
@@ -51,6 +51,7 @@
     position: absolute;
     top: 8.6rem;
     display: none;
+    box-shadow: $modal-shadow;
 
     &.opened {
       display: block;

--- a/src/components/commons/inputs/DateField.module.scss
+++ b/src/components/commons/inputs/DateField.module.scss
@@ -49,8 +49,11 @@
 
   &-day-picker {
     position: absolute;
+    z-index: $modal-level;
     top: 8.6rem;
+
     display: none;
+
     box-shadow: $modal-shadow;
 
     &.opened {

--- a/src/components/commons/inputs/DateField.tsx
+++ b/src/components/commons/inputs/DateField.tsx
@@ -8,7 +8,7 @@ import { DayPicker, DateFormatter } from 'react-day-picker';
 import { useFormContext } from 'react-hook-form';
 
 import { SVGS } from '@/constants';
-import { getAfter61Days, getDayPickerFormatDate, getYesterday } from '@/utils';
+import { getAfter31Days, getDayPickerFormatDate, getYesterday } from '@/utils';
 
 import useTogglePopup from '@/hooks/useTogglePopup';
 
@@ -37,11 +37,11 @@ export const DateField = ({ label, name }: DateFieldProps) => {
   const formattedDate = selected ? getDayPickerFormatDate(selected) : '';
 
   const yesterday = getYesterday();
-  const after61Days = getAfter61Days();
+  const after31Days = getAfter31Days();
 
   const disabledDays = [
     { from: new Date(1990, 1, 20), to: yesterday },
-    { from: after61Days, to: new Date(2100, 1, 20) },
+    { from: after31Days, to: new Date(2100, 1, 20) },
   ];
 
   const formatWeekdayName: DateFormatter = (date, options) => format(date, 'EEE', { locale: options?.locale });

--- a/src/components/commons/inputs/DateField.tsx
+++ b/src/components/commons/inputs/DateField.tsx
@@ -8,7 +8,7 @@ import { DayPicker, DateFormatter } from 'react-day-picker';
 import { useFormContext } from 'react-hook-form';
 
 import { SVGS } from '@/constants';
-import { getDayPickerFormatDate } from '@/utils';
+import { getAfter61Days, getDayPickerFormatDate, getYesterday } from '@/utils';
 
 import useTogglePopup from '@/hooks/useTogglePopup';
 
@@ -36,9 +36,13 @@ export const DateField = ({ label, name }: DateFieldProps) => {
   const isError = !!errors[name]?.message;
   const formattedDate = selected ? getDayPickerFormatDate(selected) : '';
 
-  const yesterday = new Date();
-  yesterday.setDate(yesterday.getDate() - 1);
-  const disabledDays = [{ from: new Date(1990, 1, 20), to: yesterday }];
+  const yesterday = getYesterday();
+  const after61Days = getAfter61Days();
+
+  const disabledDays = [
+    { from: new Date(1990, 1, 20), to: yesterday },
+    { from: after61Days, to: new Date(2100, 1, 20) },
+  ];
 
   const formatWeekdayName: DateFormatter = (date, options) => format(date, 'EEE', { locale: options?.locale });
 

--- a/src/utils/getDate.ts
+++ b/src/utils/getDate.ts
@@ -71,9 +71,9 @@ export const getYesterday = () => {
   return yesterday;
 };
 
-export const getAfter61Days = () => {
-  const after60Days = new Date();
-  const day = after60Days.getDate();
-  after60Days.setDate(day + 61);
-  return after60Days;
+export const getAfter31Days = () => {
+  const after31Days = new Date();
+  const day = after31Days.getDate();
+  after31Days.setDate(day + 31);
+  return after31Days;
 };

--- a/src/utils/getDate.ts
+++ b/src/utils/getDate.ts
@@ -64,3 +64,16 @@ export const formatTimestamp = (timestamp: number) => {
   const formattedTime = dayjs(timestamp).format('HH:mm');
   return formattedTime;
 };
+
+export const getYesterday = () => {
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  return yesterday;
+};
+
+export const getAfter61Days = () => {
+  const after60Days = new Date();
+  const day = after60Days.getDate();
+  after60Days.setDate(day + 61);
+  return after60Days;
+};


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

1. day picker 모달에 box shadow, z-index 추가했습니다
2. 오늘로부터 30일까지만 날짜 선택할 수 있도록 day picker 수정했습니다.
