### PR TITLE
Hotfix: Avartar 컴포넌트 layout 프롭 삭제, sizes='100%' 적용

### DIFF
--- a/src/components/commons/Avatar/index.tsx
+++ b/src/components/commons/Avatar/index.tsx
@@ -26,7 +26,7 @@ const Avatar = ({ size, profileImageUrl, isActivated }: AvatarProps) => {
       <div className={cx('dot', 'dot-left', { 'dot-activated': isActivated })}></div>
       <div className={cx('frame-inner', `frame-inner-${size}`, { 'frame-inner-activated': isActivated })}>
         {profileImageUrl ? (
-          <Image src={profileImageUrl} alt='profileImage' layout='fill' />
+          <Image src={profileImageUrl} alt='profileImage' fill sizes='100%' />
         ) : (
           <Image src={url} alt={alt} width={imageSize} height={imageSize} />
         )}


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 문제:  Avartar 컴포넌트 사용시 로컬 콘솔에서 layout 프롭 사용하지 말라는 경고문구가 떴습니다.
-  해결: layout 프롭 삭제, sizes='100%' 적용했습니다.

