### PR TITLE
Hotfix: ImageField 옵셔널 프롭 및 리스트 css 수정

### DIFF
--- a/src/components/commons/inputs/ImageField.module.scss
+++ b/src/components/commons/inputs/ImageField.module.scss
@@ -47,9 +47,14 @@
     &-name-list {
       @include column-flexbox(center, start, 0.8rem);
 
+      display: none;
       width: 100%;
       margin-right: auto;
       padding-top: 1.2rem;
+
+      &.is-showed {
+        display: block;
+      }
 
       &-item {
         @include flexbox(between);

--- a/src/components/commons/inputs/ImageField.tsx
+++ b/src/components/commons/inputs/ImageField.tsx
@@ -22,14 +22,15 @@ const { url: closeDefaultUrl, alt: closeDefaultAlt } = SVGS.close.default;
 const { url: closeActiveUrl, alt: closeActiveAlt } = SVGS.close.active;
 
 const FIFTY_MB = 1024 * 1024 * 50;
-const MAX_FILES = 5;
 
 type ImageFiledProps = {
   label: string;
   onFilesUpdate: (updatedFiles: File[]) => void;
+  maxFiles?: number;
+  onFileDelete?: (deletedFile: File) => void;
 };
 
-export const ImageField = ({ label, onFilesUpdate }: ImageFiledProps) => {
+export const ImageField = ({ label, onFilesUpdate, maxFiles = 5, onFileDelete }: ImageFiledProps) => {
   const [files, setFiles] = useState<{ file: File; isCloseActive: boolean }[]>([]);
   const [finalFiles, setFinalFiles] = useState<File[]>([]);
 
@@ -55,7 +56,7 @@ export const ImageField = ({ label, onFilesUpdate }: ImageFiledProps) => {
     accept: {
       'image/*': ['.jpeg', '.jpg', '.png'],
     },
-    maxFiles: MAX_FILES,
+    maxFiles: maxFiles,
     maxSize: FIFTY_MB,
   });
 
@@ -66,6 +67,7 @@ export const ImageField = ({ label, onFilesUpdate }: ImageFiledProps) => {
   const handleDelete = (fileIndex: string) => {
     const updatedFiles = files.filter((_, index) => index !== Number(fileIndex));
     const filteredFiles = finalFiles.filter((_, index) => index !== Number(fileIndex));
+    onFileDelete?.(finalFiles[Number(fileIndex)]);
     setFiles(updatedFiles);
     setFinalFiles(filteredFiles);
   };

--- a/src/components/commons/inputs/ImageField.tsx
+++ b/src/components/commons/inputs/ImageField.tsx
@@ -114,7 +114,7 @@ export const ImageField = ({ label, onFilesUpdate, maxFiles = 5, onFileDelete }:
           </p>
         </button>
 
-        <ul className={cx('image-field-container-name-list')}>
+        <ul className={cx('image-field-container-name-list', { 'is-showed': files.length > 0 })}>
           {files.map((item, index) => (
             <li className={cx('image-field-container-name-list-item')} key={`filename-${index}`}>
               <div className={cx('item-group')}>


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

1. 이미지 파일 삭제시 삭제 파일 반환하는 onFileDelete와 이미지 첨부 가능 개수인 maxfiles을 옵셔널 프롭으로 추가했습니다.
2. 이미지 첨부되지 않았을 때 리스트 영역 display none 처리했습니다.
