### PR TITLE
Feat[#99] 마이페이지/예약현황 모달창 구현

### DIFF
--- a/src/components/calendar/ListBody/index.tsx
+++ b/src/components/calendar/ListBody/index.tsx
@@ -3,14 +3,14 @@ import classNames from 'classnames/bind';
 import ListCard from '@/components/calendar/ListCard';
 import EmptyCard from '@/components/layout/empty/EmptyCard';
 
-import { MonthlySchedule } from '@/types';
+import { MonthlyReservationResponse } from '@/types';
 
 import styles from './ListBody.module.scss';
 
 const cx = classNames.bind(styles);
 
 type ListBodyProps = {
-  schedules?: MonthlySchedule[];
+  schedules?: MonthlyReservationResponse[];
   onClick: (date: string) => void;
 };
 

--- a/src/components/calendar/ModalCard/ModalCard.module.scss
+++ b/src/components/calendar/ModalCard/ModalCard.module.scss
@@ -1,0 +1,32 @@
+.modal-card {
+  &-container {
+    @include column-flexbox(start, stretch, 0.8rem);
+
+    padding: 1.2rem;
+    background-color: $black80;
+    border-radius: 0.8rem;
+  }
+
+  &-text {
+    @include column-flexbox(start, stretch, 0.4rem);
+
+    &-line {
+      @include flexbox(start, center, 0.8rem);
+    }
+
+    &-title {
+      @include text-style(14, $gray30);
+
+      display: inline-block;
+      width: 4rem;
+    }
+
+    &-value {
+      @include text-style(14, $white);
+    }
+  }
+
+  &-button {
+    @include flexbox(end, center, 0.8rem);
+  }
+}

--- a/src/components/calendar/ModalCard/index.tsx
+++ b/src/components/calendar/ModalCard/index.tsx
@@ -1,0 +1,51 @@
+import { Fragment } from 'react';
+
+import classNames from 'classnames/bind';
+
+import Badge from '@/components/commons/Badge';
+import { BaseButton } from '@/components/commons/buttons';
+
+import { MyReservationsStatus } from '@/types';
+
+import styles from './ModalCard.module.scss';
+
+const cx = classNames.bind(styles);
+
+type ModalCardProps = {
+  nickName: string;
+  headCount: number;
+  status: MyReservationsStatus;
+};
+
+const ModalCard = ({ nickName, headCount, status }: ModalCardProps) => {
+  return (
+    <div className={cx('modal-card-container')}>
+      <div className={cx('modal-card-text')}>
+        <div className={cx('modal-card-text-line')}>
+          <span className={cx('modal-card-text-title')}>닉네임</span>
+          <span className={cx('modal-card-text-value')}>{nickName}</span>
+        </div>
+        <div className={cx('modal-card-text-line')}>
+          <span className={cx('modal-card-text-title')}>인원</span>
+          <span className={cx('modal-card-text-value')}>{headCount}명</span>
+        </div>
+      </div>
+      <div className={cx('modal-card-button')}>
+        {status === 'pending' ? (
+          <Fragment>
+            <BaseButton theme='outline' size='small'>
+              거절
+            </BaseButton>
+            <BaseButton theme='ghost' size='small'>
+              승인
+            </BaseButton>
+          </Fragment>
+        ) : (
+          <Badge status={status} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ModalCard;

--- a/src/components/calendar/ModalCard/index.tsx
+++ b/src/components/calendar/ModalCard/index.tsx
@@ -15,9 +15,10 @@ type ModalCardProps = {
   nickName: string;
   headCount: number;
   status: MyReservationsStatus;
+  onClickButton: (text: string) => void;
 };
 
-const ModalCard = ({ nickName, headCount, status }: ModalCardProps) => {
+const ModalCard = ({ nickName, headCount, status, onClickButton }: ModalCardProps) => {
   return (
     <div className={cx('modal-card-container')}>
       <div className={cx('modal-card-text')}>
@@ -33,10 +34,10 @@ const ModalCard = ({ nickName, headCount, status }: ModalCardProps) => {
       <div className={cx('modal-card-button')}>
         {status === 'pending' ? (
           <Fragment>
-            <BaseButton theme='outline' size='small'>
+            <BaseButton theme='outline' size='small' onClick={() => onClickButton('거절')}>
               거절
             </BaseButton>
-            <BaseButton theme='ghost' size='small'>
+            <BaseButton theme='ghost' size='small' onClick={() => onClickButton('승인')}>
               승인
             </BaseButton>
           </Fragment>

--- a/src/components/calendar/ModalContents/ModalContents.module.scss
+++ b/src/components/calendar/ModalContents/ModalContents.module.scss
@@ -54,7 +54,10 @@
   }
 
   &-close {
-    flex-grow: 0;
+    @include responsive(T) {
+      margin: 0;
+    }
+
     margin: 0 auto;
   }
 }

--- a/src/components/calendar/ModalContents/ModalContents.module.scss
+++ b/src/components/calendar/ModalContents/ModalContents.module.scss
@@ -30,10 +30,26 @@
     &-card {
       @include column-flexbox(start, stretch, 0.8rem);
 
-      @include no-scrollbar;
-
-      overflow-y: scroll;
+      overflow-y: auto;
       max-height: 23.2rem;
+
+      &::-webkit-scrollbar {
+        width: 0.6rem;
+      }
+
+      &::-webkit-scrollbar-track {
+        background: $opacity-white-5;
+        border-radius: 9.9rem;
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background-color: $gray10;
+        border-radius: 9.9rem;
+      }
+
+      &.scroll {
+        padding-right: 0.8rem;
+      }
     }
   }
 

--- a/src/components/calendar/ModalContents/ModalContents.module.scss
+++ b/src/components/calendar/ModalContents/ModalContents.module.scss
@@ -2,4 +2,34 @@
   &-container {
     @include column-flexbox(start, stretch, 1.6rem);
   }
+
+  &-date {
+    @include column-flexbox(start, stretch, 0.8rem);
+
+    &-title {
+      @include text-style(16, $white, bold);
+    }
+
+    &-korean {
+      @include text-style(14, $gray10);
+    }
+  }
+
+  &-reservation {
+    @include column-flexbox(start, stretch, 0.8rem);
+
+    &-title {
+      @include flexbox(start, center, 0.4rem);
+      @include text-style(16, $white, bold);
+    }
+
+    &-count {
+      @include text-style(14, $primary, bold);
+    }
+  }
+
+  &-close {
+    flex-grow: 0;
+    margin: 0 auto;
+  }
 }

--- a/src/components/calendar/ModalContents/ModalContents.module.scss
+++ b/src/components/calendar/ModalContents/ModalContents.module.scss
@@ -33,7 +33,7 @@
       @include no-scrollbar;
 
       overflow-y: scroll;
-      max-height: 24rem;
+      max-height: 23.2rem;
     }
   }
 

--- a/src/components/calendar/ModalContents/ModalContents.module.scss
+++ b/src/components/calendar/ModalContents/ModalContents.module.scss
@@ -1,0 +1,5 @@
+.schedule-modal {
+  &-container {
+    @include column-flexbox(start, stretch, 1.6rem);
+  }
+}

--- a/src/components/calendar/ModalContents/ModalContents.module.scss
+++ b/src/components/calendar/ModalContents/ModalContents.module.scss
@@ -26,6 +26,15 @@
     &-count {
       @include text-style(14, $primary, bold);
     }
+
+    &-card {
+      @include column-flexbox(start, stretch, 0.8rem);
+
+      @include no-scrollbar;
+
+      overflow-y: scroll;
+      max-height: 24rem;
+    }
   }
 
   &-close {

--- a/src/components/calendar/ModalContents/ModalContents.module.scss
+++ b/src/components/calendar/ModalContents/ModalContents.module.scss
@@ -1,6 +1,11 @@
 .schedule-modal {
   &-container {
     @include column-flexbox(start, stretch, 1.6rem);
+
+    @include responsive(T) {
+      justify-content: space-between;
+      height: 100%;
+    }
   }
 
   &-date {
@@ -17,6 +22,10 @@
 
   &-reservation {
     @include column-flexbox(start, stretch, 0.8rem);
+
+    @include responsive(T) {
+      flex-grow: 1;
+    }
 
     &-title {
       @include flexbox(start, center, 0.4rem);

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -24,10 +24,11 @@ const cx = classNames.bind(styles);
 type ModalContentsProps = {
   gameId: number;
   activeDate: string;
-  onClick: MouseEventHandler<HTMLButtonElement>;
+  onClickCloseButton: MouseEventHandler<HTMLButtonElement>;
+  onClickCardButton: (text: string) => void;
 };
 
-const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
+const ModalContents = ({ gameId, activeDate, onClickCloseButton, onClickCardButton }: ModalContentsProps) => {
   const DailyMockData: Record<string, DailyReservationResponse[]> = {
     '2024-03-27': DailyScheduleMockData['2024-03-27'],
     '2024-03-30': DailyScheduleMockData['2024-03-30'],
@@ -86,7 +87,12 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
           <ul className={cx('schedule-modal-reservation-card', { scroll: totalCount > 2 })}>
             {reservations.map(({ nickname, headCount, status, id }) => (
               <li key={`card-${id}`}>
-                <ModalCard nickName={nickname} headCount={headCount} status={status as MyReservationsStatus} />
+                <ModalCard
+                  nickName={nickname}
+                  headCount={headCount}
+                  status={status as MyReservationsStatus}
+                  onClickButton={onClickCardButton}
+                />
               </li>
             ))}
           </ul>
@@ -95,7 +101,7 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
         )}
       </div>
       <div className={cx('schedule-modal-close')}>
-        <BaseButton theme='outline' size='medium' onClick={onClick}>
+        <BaseButton theme='outline' size='medium' onClick={onClickCloseButton}>
           닫기
         </BaseButton>
       </div>

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -8,6 +8,7 @@ import ModalCard from '@/components/calendar/ModalCard';
 import { BaseButton } from '@/components/commons/buttons';
 import Dropdown from '@/components/commons/Dropdown';
 import Tab from '@/components/commons/Tab';
+import EmptyCard from '@/components/layout/empty/EmptyCard';
 import reservationDetailMockDataConfirmed from '@/constants/mockData/reservationDetailMockDataConfirmed.json';
 import reservationDetailMockDataDeclined from '@/constants/mockData/reservationDetailMockDataDeclined.json';
 import reservationDetailMockDataPending from '@/constants/mockData/reservationDetailMockDataPending.json';
@@ -81,13 +82,17 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
           <span>예약 내역</span>
           <span className={cx('schedule-modal-reservation-count')}>{reservationData.totalCount}</span>
         </h3>
-        <ul className={cx('schedule-modal-reservation-card')}>
-          {reservationData.reservations.map(({ nickname, headCount, status, id }) => (
-            <li key={`card-${id}`}>
-              <ModalCard nickName={nickname} headCount={headCount} status={status as MyReservationsStatus} />
-            </li>
-          ))}
-        </ul>
+        {reservationData.totalCount !== 0 ? (
+          <ul className={cx('schedule-modal-reservation-card')}>
+            {reservationData.reservations.map(({ nickname, headCount, status, id }) => (
+              <li key={`card-${id}`}>
+                <ModalCard nickName={nickname} headCount={headCount} status={status as MyReservationsStatus} />
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyCard text='No Reservation' isSmall />
+        )}
       </div>
       <div className={cx('schedule-modal-close')}>
         <BaseButton theme='outline' size='medium' onClick={onClick}>

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { MouseEventHandler, useState } from 'react';
 
 import classNames from 'classnames/bind';
 
 import { getDateStringKR, getScheduleDropdownOption, getStatusCountByScheduleId } from '@/utils';
 
+import { BaseButton } from '@/components/commons/buttons';
 import Dropdown from '@/components/commons/Dropdown';
 import Tab from '@/components/commons/Tab';
 import DailyScheduleMockData from '@/constants/mockData/reservedScheduleMockData.json';
@@ -17,9 +18,10 @@ const cx = classNames.bind(styles);
 type ModalContentsProps = {
   gameId: number;
   activeDate: string;
+  onClick: MouseEventHandler<HTMLButtonElement>;
 };
 
-const ModalContents = ({ gameId, activeDate }: ModalContentsProps) => {
+const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
   const DailyMockData: Record<string, DailyReservationResponse[]> = {
     '2024-03-27': DailyScheduleMockData['2024-03-27'],
     '2024-03-30': DailyScheduleMockData['2024-03-30'],
@@ -40,6 +42,7 @@ const ModalContents = ({ gameId, activeDate }: ModalContentsProps) => {
   ];
 
   const [selectedTabId, setSelectedTabId] = useState<MyReservationsStatus>(statusTabOptions[0].id);
+  const totalCount = Object.values(statusCount).reduce((prev, cur) => prev + cur, 0);
 
   console.log(gameId);
 
@@ -53,7 +56,7 @@ const ModalContents = ({ gameId, activeDate }: ModalContentsProps) => {
       />
       <div className={cx('schedule-modal-date')}>
         <h3 className={cx('schedule-modal-date-title')}>예약 날짜</h3>
-        <span className={cx('schedule-modal-date-kr')}>{getDateStringKR(activeDate)}</span>
+        <span className={cx('schedule-modal-date-korean')}>{getDateStringKR(activeDate)}</span>
         <Dropdown
           options={dropdownOptions}
           onChange={(value) => {
@@ -62,6 +65,17 @@ const ModalContents = ({ gameId, activeDate }: ModalContentsProps) => {
           color='yellow'
           isSmall
         />
+      </div>
+      <div className={cx('schedule-modal-reservation')}>
+        <h3 className={cx('schedule-modal-reservation-title')}>
+          <span>예약 내역</span>
+          <span className={cx('schedule-modal-reservation-count')}>{totalCount}</span>
+        </h3>
+      </div>
+      <div className={cx('schedule-modal-close')}>
+        <BaseButton theme='outline' size='medium' onClick={onClick}>
+          닫기
+        </BaseButton>
       </div>
     </div>
   );

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -8,9 +8,13 @@ import ModalCard from '@/components/calendar/ModalCard';
 import { BaseButton } from '@/components/commons/buttons';
 import Dropdown from '@/components/commons/Dropdown';
 import Tab from '@/components/commons/Tab';
+import reservationDetailMockDataConfirmed from '@/constants/mockData/reservationDetailMockDataConfirmed.json';
+import reservationDetailMockDataDeclined from '@/constants/mockData/reservationDetailMockDataDeclined.json';
+import reservationDetailMockDataPending from '@/constants/mockData/reservationDetailMockDataPending.json';
+import reservationDetailMockDataPendingNoData from '@/constants/mockData/reservationDetailMockDataPendingNoData.json';
 import DailyScheduleMockData from '@/constants/mockData/reservedScheduleMockData.json';
 
-import { DailyReservationResponse, MyReservationsStatus, StatusTabOptions } from '@/types';
+import { DailyReservationResponse, DetailReservationResponse, MyReservationsStatus, StatusTabOptions } from '@/types';
 
 import styles from './ModalContents.module.scss';
 
@@ -29,6 +33,13 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
     '2024-04-01': DailyScheduleMockData['2024-04-01'],
   };
 
+  const ReservationMockData: Record<string, DetailReservationResponse> = {
+    '0-confirmed': reservationDetailMockDataConfirmed as DetailReservationResponse,
+    '0-declined': reservationDetailMockDataDeclined as DetailReservationResponse,
+    '0-pending': reservationDetailMockDataPending as DetailReservationResponse,
+    '1-pending': reservationDetailMockDataPendingNoData as DetailReservationResponse,
+  };
+
   const dropdownOptions = getScheduleDropdownOption(DailyMockData[activeDate]);
   const statusCountByScheduleId = getStatusCountByScheduleId(DailyMockData[activeDate]);
 
@@ -43,6 +54,8 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
   ];
 
   const [selectedStatus, setSelectedStatus] = useState<MyReservationsStatus>(statusTabOptions[0].id);
+
+  const reservationData = ReservationMockData[`${scheduleId}-${selectedStatus}`];
 
   const handleChangeScheduleId = (value: string | number) => {
     setScheduleId(value as number);
@@ -66,14 +79,15 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
       <div className={cx('schedule-modal-reservation')}>
         <h3 className={cx('schedule-modal-reservation-title')}>
           <span>예약 내역</span>
-          <span className={cx('schedule-modal-reservation-count')}>0</span>
+          <span className={cx('schedule-modal-reservation-count')}>{reservationData.totalCount}</span>
         </h3>
-        <div className={cx('schedule-modal-reservation-card')}>
-          <ModalCard nickName={'닉네임a'} headCount={1} status={'pending'} />
-          <ModalCard nickName={'닉네임s'} headCount={2} status={'declined'} />
-          <ModalCard nickName={'닉네임d'} headCount={3} status={'confirmed'} />
-          <ModalCard nickName={'닉네임f'} headCount={4} status={'pending'} />
-        </div>
+        <ul className={cx('schedule-modal-reservation-card')}>
+          {reservationData.reservations.map(({ nickname, headCount, status, id }) => (
+            <li key={`card-${id}`}>
+              <ModalCard nickName={nickname} headCount={headCount} status={status as MyReservationsStatus} />
+            </li>
+          ))}
+        </ul>
       </div>
       <div className={cx('schedule-modal-close')}>
         <BaseButton theme='outline' size='medium' onClick={onClick}>

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -14,6 +14,7 @@ import reservationDetailMockDataDeclined from '@/constants/mockData/reservationD
 import reservationDetailMockDataPending from '@/constants/mockData/reservationDetailMockDataPending.json';
 import reservationDetailMockDataPendingNoData from '@/constants/mockData/reservationDetailMockDataPendingNoData.json';
 import DailyScheduleMockData from '@/constants/mockData/reservedScheduleMockData.json';
+import { useDeviceType } from '@/hooks/useDeviceType';
 
 import { DailyReservationResponse, DetailReservationResponse, MyReservationsStatus, StatusTabOptions } from '@/types';
 
@@ -56,6 +57,8 @@ const ModalContents = ({ gameId, activeDate, onClickCloseButton, onClickCardButt
   ];
 
   const [selectedStatus, setSelectedStatus] = useState<MyReservationsStatus>(statusTabOptions[0].id);
+
+  const currentDeviceType = useDeviceType();
 
   const { totalCount, reservations } = ReservationMockData[`${scheduleId}-${selectedStatus}`];
 
@@ -101,7 +104,7 @@ const ModalContents = ({ gameId, activeDate, onClickCloseButton, onClickCardButt
         )}
       </div>
       <div className={cx('schedule-modal-close')}>
-        <BaseButton theme='outline' size='medium' onClick={onClickCloseButton}>
+        <BaseButton theme='outline' size={currentDeviceType === 'PC' ? 'medium' : 'large'} onClick={onClickCloseButton}>
           닫기
         </BaseButton>
       </div>

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -2,11 +2,13 @@ import { useState } from 'react';
 
 import classNames from 'classnames/bind';
 
-import { SCHEDULE_TAB_OPTIONS } from '@/constants';
+import { getDateStringKR, getScheduleDropdownOption, getStatusCountByScheduleId } from '@/utils';
 
+import Dropdown from '@/components/commons/Dropdown';
 import Tab from '@/components/commons/Tab';
+import DailyScheduleMockData from '@/constants/mockData/reservedScheduleMockData.json';
 
-import { MyReservationsStatus } from '@/types';
+import { DailyReservationResponse, MyReservationsStatus, StatusTabOptions } from '@/types';
 
 import styles from './ModalContents.module.scss';
 
@@ -18,19 +20,49 @@ type ModalContentsProps = {
 };
 
 const ModalContents = ({ gameId, activeDate }: ModalContentsProps) => {
-  const [selectedTabId, setSelectedTabId] = useState<MyReservationsStatus>(SCHEDULE_TAB_OPTIONS[0].id);
+  const DailyMockData: Record<string, DailyReservationResponse[]> = {
+    '2024-03-27': DailyScheduleMockData['2024-03-27'],
+    '2024-03-30': DailyScheduleMockData['2024-03-30'],
+    '2024-04-01': DailyScheduleMockData['2024-04-01'],
+  };
+
+  const dropdownOptions = getScheduleDropdownOption(DailyMockData[activeDate]);
+  const statusCountByScheduleId = getStatusCountByScheduleId(DailyMockData[activeDate]);
+
+  const [scheduleId, setScheduleId] = useState(dropdownOptions[0].value as number);
+
+  const statusCount = statusCountByScheduleId[scheduleId];
+
+  const statusTabOptions: StatusTabOptions[] = [
+    { id: 'pending', text: '신청', count: statusCount.pending },
+    { id: 'confirmed', text: '승인', count: statusCount.confirmed },
+    { id: 'declined', text: '거절', count: statusCount.declined },
+  ];
+
+  const [selectedTabId, setSelectedTabId] = useState<MyReservationsStatus>(statusTabOptions[0].id);
 
   console.log(gameId);
-  console.log(activeDate);
 
   return (
     <div className={cx('schedule-modal-container')}>
       <Tab
-        items={SCHEDULE_TAB_OPTIONS}
+        items={statusTabOptions}
         size='small'
         selectedTabId={selectedTabId}
         onClick={(selectedId) => setSelectedTabId(selectedId as MyReservationsStatus)}
       />
+      <div className={cx('schedule-modal-date')}>
+        <h3 className={cx('schedule-modal-date-title')}>예약 날짜</h3>
+        <span className={cx('schedule-modal-date-kr')}>{getDateStringKR(activeDate)}</span>
+        <Dropdown
+          options={dropdownOptions}
+          onChange={(value) => {
+            setScheduleId(value as number);
+          }}
+          color='yellow'
+          isSmall
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames/bind';
 
 import { getDateStringKR, getScheduleDropdownOption, getStatusCountByScheduleId } from '@/utils';
 
+import ModalCard from '@/components/calendar/ModalCard';
 import { BaseButton } from '@/components/commons/buttons';
 import Dropdown from '@/components/commons/Dropdown';
 import Tab from '@/components/commons/Tab';
@@ -43,6 +44,10 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
 
   const [selectedStatus, setSelectedStatus] = useState<MyReservationsStatus>(statusTabOptions[0].id);
 
+  const handleChangeScheduleId = (value: string | number) => {
+    setScheduleId(value as number);
+  };
+
   console.log(gameId);
 
   return (
@@ -56,20 +61,19 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
       <div className={cx('schedule-modal-date')}>
         <h3 className={cx('schedule-modal-date-title')}>예약 날짜</h3>
         <span className={cx('schedule-modal-date-korean')}>{getDateStringKR(activeDate)}</span>
-        <Dropdown
-          options={dropdownOptions}
-          onChange={(value) => {
-            setScheduleId(value as number);
-          }}
-          color='yellow'
-          isSmall
-        />
+        <Dropdown options={dropdownOptions} onChange={handleChangeScheduleId} color='yellow' isSmall />
       </div>
       <div className={cx('schedule-modal-reservation')}>
         <h3 className={cx('schedule-modal-reservation-title')}>
           <span>예약 내역</span>
           <span className={cx('schedule-modal-reservation-count')}>0</span>
         </h3>
+        <div className={cx('schedule-modal-reservation-card')}>
+          <ModalCard nickName={'닉네임a'} headCount={1} status={'pending'} />
+          <ModalCard nickName={'닉네임s'} headCount={2} status={'declined'} />
+          <ModalCard nickName={'닉네임d'} headCount={3} status={'confirmed'} />
+          <ModalCard nickName={'닉네임f'} headCount={4} status={'pending'} />
+        </div>
       </div>
       <div className={cx('schedule-modal-close')}>
         <BaseButton theme='outline' size='medium' onClick={onClick}>

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -4,8 +4,17 @@ import styles from './ModalContents.module.scss';
 
 const cx = classNames.bind(styles);
 
-const ModalContents = () => {
-  return <div className={cx('')}>ModalContents</div>;
+type ModalContentsProps = {
+  gameId: number;
+  activeDate: string;
+};
+
+const ModalContents = ({ gameId, activeDate }: ModalContentsProps) => {
+  return (
+    <div className={cx('')}>
+      {gameId} / {activeDate}
+    </div>
+  );
 };
 
 export default ModalContents;

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -41,8 +41,7 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
     { id: 'declined', text: '거절', count: statusCount.declined },
   ];
 
-  const [selectedTabId, setSelectedTabId] = useState<MyReservationsStatus>(statusTabOptions[0].id);
-  const totalCount = Object.values(statusCount).reduce((prev, cur) => prev + cur, 0);
+  const [selectedStatus, setSelectedStatus] = useState<MyReservationsStatus>(statusTabOptions[0].id);
 
   console.log(gameId);
 
@@ -51,8 +50,8 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
       <Tab
         items={statusTabOptions}
         size='small'
-        selectedTabId={selectedTabId}
-        onClick={(selectedId) => setSelectedTabId(selectedId as MyReservationsStatus)}
+        selectedTabId={selectedStatus}
+        onClick={(selectedId) => setSelectedStatus(selectedId as MyReservationsStatus)}
       />
       <div className={cx('schedule-modal-date')}>
         <h3 className={cx('schedule-modal-date-title')}>예약 날짜</h3>
@@ -69,7 +68,7 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
       <div className={cx('schedule-modal-reservation')}>
         <h3 className={cx('schedule-modal-reservation-title')}>
           <span>예약 내역</span>
-          <span className={cx('schedule-modal-reservation-count')}>{totalCount}</span>
+          <span className={cx('schedule-modal-reservation-count')}>0</span>
         </h3>
       </div>
       <div className={cx('schedule-modal-close')}>

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -56,7 +56,7 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
 
   const [selectedStatus, setSelectedStatus] = useState<MyReservationsStatus>(statusTabOptions[0].id);
 
-  const reservationData = ReservationMockData[`${scheduleId}-${selectedStatus}`];
+  const { totalCount, reservations } = ReservationMockData[`${scheduleId}-${selectedStatus}`];
 
   const handleChangeScheduleId = (value: string | number) => {
     setScheduleId(value as number);
@@ -80,11 +80,11 @@ const ModalContents = ({ gameId, activeDate, onClick }: ModalContentsProps) => {
       <div className={cx('schedule-modal-reservation')}>
         <h3 className={cx('schedule-modal-reservation-title')}>
           <span>예약 내역</span>
-          <span className={cx('schedule-modal-reservation-count')}>{reservationData.totalCount}</span>
+          <span className={cx('schedule-modal-reservation-count')}>{totalCount}</span>
         </h3>
-        {reservationData.totalCount !== 0 ? (
-          <ul className={cx('schedule-modal-reservation-card')}>
-            {reservationData.reservations.map(({ nickname, headCount, status, id }) => (
+        {totalCount !== 0 ? (
+          <ul className={cx('schedule-modal-reservation-card', { scroll: totalCount > 2 })}>
+            {reservations.map(({ nickname, headCount, status, id }) => (
               <li key={`card-${id}`}>
                 <ModalCard nickName={nickname} headCount={headCount} status={status as MyReservationsStatus} />
               </li>

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -1,4 +1,12 @@
+import { useState } from 'react';
+
 import classNames from 'classnames/bind';
+
+import { SCHEDULE_TAB_OPTIONS } from '@/constants';
+
+import Tab from '@/components/commons/Tab';
+
+import { MyReservationsStatus } from '@/types';
 
 import styles from './ModalContents.module.scss';
 
@@ -10,9 +18,19 @@ type ModalContentsProps = {
 };
 
 const ModalContents = ({ gameId, activeDate }: ModalContentsProps) => {
+  const [selectedTabId, setSelectedTabId] = useState<MyReservationsStatus>(SCHEDULE_TAB_OPTIONS[0].id);
+
+  console.log(gameId);
+  console.log(activeDate);
+
   return (
-    <div className={cx('')}>
-      {gameId} / {activeDate}
+    <div className={cx('schedule-modal-container')}>
+      <Tab
+        items={SCHEDULE_TAB_OPTIONS}
+        size='small'
+        selectedTabId={selectedTabId}
+        onClick={(selectedId) => setSelectedTabId(selectedId as MyReservationsStatus)}
+      />
     </div>
   );
 };

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -37,10 +37,10 @@ const ModalContents = ({ gameId, activeDate, onClickCloseButton, onClickCardButt
   };
 
   const ReservationMockData: Record<string, DetailReservationResponse> = {
-    '0-confirmed': reservationDetailMockDataConfirmed as DetailReservationResponse,
-    '0-declined': reservationDetailMockDataDeclined as DetailReservationResponse,
-    '0-pending': reservationDetailMockDataPending as DetailReservationResponse,
-    '1-pending': reservationDetailMockDataPendingNoData as DetailReservationResponse,
+    '1-0-confirmed': reservationDetailMockDataConfirmed as DetailReservationResponse,
+    '1-0-declined': reservationDetailMockDataDeclined as DetailReservationResponse,
+    '1-0-pending': reservationDetailMockDataPending as DetailReservationResponse,
+    '1-1-pending': reservationDetailMockDataPendingNoData as DetailReservationResponse,
   };
 
   const dropdownOptions = getScheduleDropdownOption(DailyMockData[activeDate]);
@@ -60,22 +60,19 @@ const ModalContents = ({ gameId, activeDate, onClickCloseButton, onClickCardButt
 
   const currentDeviceType = useDeviceType();
 
-  const { totalCount, reservations } = ReservationMockData[`${scheduleId}-${selectedStatus}`];
+  const { totalCount, reservations } = ReservationMockData[`${gameId}-${scheduleId}-${selectedStatus}`];
+
+  const handleChangeTabId = (selectedId: string | number) => {
+    setSelectedStatus(selectedId as MyReservationsStatus);
+  };
 
   const handleChangeScheduleId = (value: string | number) => {
     setScheduleId(value as number);
   };
 
-  console.log(gameId);
-
   return (
     <div className={cx('schedule-modal-container')}>
-      <Tab
-        items={statusTabOptions}
-        size='small'
-        selectedTabId={selectedStatus}
-        onClick={(selectedId) => setSelectedStatus(selectedId as MyReservationsStatus)}
-      />
+      <Tab items={statusTabOptions} size='small' selectedTabId={selectedStatus} onClick={handleChangeTabId} />
       <div className={cx('schedule-modal-date')}>
         <h3 className={cx('schedule-modal-date-title')}>예약 날짜</h3>
         <span className={cx('schedule-modal-date-korean')}>{getDateStringKR(activeDate)}</span>

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -16,7 +16,7 @@ import MockMonthlySchedule4 from '@/constants/mockData/myScheduleMockDataMonth4.
 import { useDeviceType } from '@/hooks/useDeviceType';
 import useMultiState from '@/hooks/useMultiState';
 
-import { MonthlySchedule } from '@/types';
+import { MonthlyReservationResponse } from '@/types';
 
 import styles from './Calendar.module.scss';
 
@@ -29,7 +29,7 @@ const getMonthlyMockData = (year: number, month: number) => {
   const yearText = year.toString();
   const monthText = month.toString().padStart(2, '0');
 
-  const MonthlyMockData: Record<string, MonthlySchedule[]> = {
+  const MonthlyMockData: Record<string, MonthlyReservationResponse[]> = {
     '2024/01': MockMonthlySchedule1,
     '2024/02': MockMonthlySchedule2,
     '2024/03': MockMonthlySchedule3,
@@ -49,7 +49,7 @@ const Calendar = ({ gameId }: CalendarProps) => {
   const [isCalendar, setIsCalendar] = useState(true);
   const [currentYear, setCurrentYear] = useState(today.year);
   const [currentMonth, setCurrentMonth] = useState(today.month);
-  const [monthlySchedule, setMonthlySchedule] = useState<MonthlySchedule[]>([]);
+  const [monthlySchedule, setMonthlySchedule] = useState<MonthlyReservationResponse[]>([]);
   const [activeDate, setActiveDate] = useState('');
 
   const { multiState, toggleClick } = useMultiState(['scheduleModal, confirmModal']);

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -8,7 +8,7 @@ import CalendarBody from '@/components/calendar/CalendarBody';
 import CalendarHeader from '@/components/calendar/CalendarHeader';
 import ListBody from '@/components/calendar/ListBody';
 import ModalContents from '@/components/calendar/ModalContents';
-import { CommonModal } from '@/components/commons/modals';
+import { CommonModal, ConfirmModal, ModalButton } from '@/components/commons/modals';
 import MockMonthlySchedule1 from '@/constants/mockData/myScheduleMockDataMonth1.json';
 import MockMonthlySchedule2 from '@/constants/mockData/myScheduleMockDataMonth2.json';
 import MockMonthlySchedule3 from '@/constants/mockData/myScheduleMockDataMonth3.json';
@@ -51,6 +51,7 @@ const Calendar = ({ gameId }: CalendarProps) => {
   const [currentMonth, setCurrentMonth] = useState(today.month);
   const [monthlySchedule, setMonthlySchedule] = useState<MonthlyReservationResponse[]>([]);
   const [activeDate, setActiveDate] = useState('');
+  const [confirmText, setConfirmText] = useState('승인');
 
   const { multiState, toggleClick } = useMultiState(['scheduleModal, confirmModal']);
   const currentDeviceType = useDeviceType();
@@ -72,6 +73,11 @@ const Calendar = ({ gameId }: CalendarProps) => {
   const handleScheduleClick = (date: string) => {
     setActiveDate(date);
     toggleClick('scheduleModal');
+  };
+
+  const handleConfirmClick = (text: string) => {
+    setConfirmText(text);
+    toggleClick('confirmModal');
   };
 
   useEffect(() => {
@@ -111,7 +117,28 @@ const Calendar = ({ gameId }: CalendarProps) => {
         onClose={() => toggleClick('scheduleModal')}
         title={'예약 정보'}
         renderContent={
-          <ModalContents gameId={gameId} activeDate={activeDate} onClick={() => toggleClick('scheduleModal')} />
+          <ModalContents
+            gameId={gameId}
+            activeDate={activeDate}
+            onClickCloseButton={() => toggleClick('scheduleModal')}
+            onClickCardButton={handleConfirmClick}
+          />
+        }
+      />
+      <ConfirmModal
+        warning
+        openModal={multiState.confirmModal}
+        onClose={() => toggleClick('confirmModal')}
+        state='WARNING'
+        title={`예약 신청을 ${confirmText}하시겠습니까?`}
+        desc={`한번 ${confirmText}한 예약은 되돌릴 수 없습니다.`}
+        renderButton={
+          <>
+            <ModalButton variant='warning' onClick={() => toggleClick('confirmModal')}>
+              확인
+            </ModalButton>
+            <ModalButton onClick={() => toggleClick('confirmModal')}>취소</ModalButton>
+          </>
         }
       />
     </>

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -69,10 +69,6 @@ const Calendar = ({ gameId }: CalendarProps) => {
     setCurrentMonth(newMonth);
   };
 
-  const handleToggleModal = (modalKey: string) => {
-    toggleClick(modalKey);
-  };
-
   const handleScheduleClick = (date: string) => {
     setActiveDate(date);
     toggleClick('scheduleModal');
@@ -112,9 +108,11 @@ const Calendar = ({ gameId }: CalendarProps) => {
       </div>
       <CommonModal
         openModal={multiState.scheduleModal}
-        onClose={() => handleToggleModal('scheduleModal')}
+        onClose={() => toggleClick('scheduleModal')}
         title={'예약 정보'}
-        renderContent={<ModalContents gameId={gameId} activeDate={activeDate} />}
+        renderContent={
+          <ModalContents gameId={gameId} activeDate={activeDate} onClick={() => toggleClick('scheduleModal')} />
+        }
       />
     </>
   );

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -7,11 +7,14 @@ import { getCurrentDate, scheduleListToObjectByDate } from '@/utils';
 import CalendarBody from '@/components/calendar/CalendarBody';
 import CalendarHeader from '@/components/calendar/CalendarHeader';
 import ListBody from '@/components/calendar/ListBody';
+import ModalContents from '@/components/calendar/ModalContents';
+import { CommonModal } from '@/components/commons/modals';
 import MockMonthlySchedule1 from '@/constants/mockData/myScheduleMockDataMonth1.json';
 import MockMonthlySchedule2 from '@/constants/mockData/myScheduleMockDataMonth2.json';
 import MockMonthlySchedule3 from '@/constants/mockData/myScheduleMockDataMonth3.json';
 import MockMonthlySchedule4 from '@/constants/mockData/myScheduleMockDataMonth4.json';
 import { useDeviceType } from '@/hooks/useDeviceType';
+import useMultiState from '@/hooks/useMultiState';
 
 import { MonthlySchedule } from '@/types';
 
@@ -49,6 +52,7 @@ const Calendar = ({ gameId }: CalendarProps) => {
   const [monthlySchedule, setMonthlySchedule] = useState<MonthlySchedule[]>([]);
   const [activeDate, setActiveDate] = useState('');
 
+  const { multiState, toggleClick } = useMultiState(['scheduleModal, confirmModal']);
   const currentDeviceType = useDeviceType();
 
   const handleChangeMonth = (addNumber: number) => {
@@ -65,8 +69,13 @@ const Calendar = ({ gameId }: CalendarProps) => {
     setCurrentMonth(newMonth);
   };
 
+  const handleToggleModal = (modalKey: string) => {
+    toggleClick(modalKey);
+  };
+
   const handleScheduleClick = (date: string) => {
     setActiveDate(date);
+    toggleClick('scheduleModal');
   };
 
   useEffect(() => {
@@ -79,30 +88,35 @@ const Calendar = ({ gameId }: CalendarProps) => {
     setMonthlySchedule(scheduleData);
   }, [currentYear, currentMonth]);
 
-  console.log(gameId);
-  console.log(activeDate);
-
   return (
-    <div className={cx('calendar-container')}>
-      <CalendarHeader
-        currentYear={currentYear}
-        currentMonth={currentMonth}
-        onChangeMonth={handleChangeMonth}
-        isCalendar={isCalendar}
-        setIsCalendar={setIsCalendar}
-      />
-      {isCalendar ? (
-        <CalendarBody
-          today={today}
+    <>
+      <div className={cx('calendar-container')}>
+        <CalendarHeader
           currentYear={currentYear}
           currentMonth={currentMonth}
-          schedules={scheduleListToObjectByDate(monthlySchedule)}
-          onClick={handleScheduleClick}
+          onChangeMonth={handleChangeMonth}
+          isCalendar={isCalendar}
+          setIsCalendar={setIsCalendar}
         />
-      ) : (
-        <ListBody schedules={monthlySchedule} onClick={handleScheduleClick} />
-      )}
-    </div>
+        {isCalendar ? (
+          <CalendarBody
+            today={today}
+            currentYear={currentYear}
+            currentMonth={currentMonth}
+            schedules={scheduleListToObjectByDate(monthlySchedule)}
+            onClick={handleScheduleClick}
+          />
+        ) : (
+          <ListBody schedules={monthlySchedule} onClick={handleScheduleClick} />
+        )}
+      </div>
+      <CommonModal
+        openModal={multiState.scheduleModal}
+        onClose={() => handleToggleModal('scheduleModal')}
+        title={'예약 정보'}
+        renderContent={<ModalContents gameId={gameId} activeDate={activeDate} />}
+      />
+    </>
   );
 };
 

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import classNames from 'classnames/bind';
 
-import { getCurrentDate, scheduleListToObjectByDate } from '@/utils';
+import { getCurrentDate, getScheduleByDate } from '@/utils';
 
 import CalendarBody from '@/components/calendar/CalendarBody';
 import CalendarHeader from '@/components/calendar/CalendarHeader';
@@ -103,7 +103,7 @@ const Calendar = ({ gameId }: CalendarProps) => {
             today={today}
             currentYear={currentYear}
             currentMonth={currentMonth}
-            schedules={scheduleListToObjectByDate(monthlySchedule)}
+            schedules={getScheduleByDate(monthlySchedule)}
             onClick={handleScheduleClick}
           />
         ) : (

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -116,6 +116,7 @@ const Calendar = ({ gameId }: CalendarProps) => {
         openModal={multiState.scheduleModal}
         onClose={() => toggleClick('scheduleModal')}
         title={'예약 정보'}
+        isResponsive
         renderContent={
           <ModalContents
             gameId={gameId}

--- a/src/components/commons/Dropdown/Dropdown.module.scss
+++ b/src/components/commons/Dropdown/Dropdown.module.scss
@@ -21,9 +21,14 @@
 
         cursor: pointer;
 
+        overflow: hidden;
+
         width: 100%;
         height: 4.8rem;
         padding: 0 5.2rem 0 1.6rem;
+
+        text-overflow: ellipsis;
+        white-space: nowrap;
 
         background: $input-background;
         border: 0.1rem solid $input-stroke;

--- a/src/components/commons/modals/CommonModal.module.scss
+++ b/src/components/commons/modals/CommonModal.module.scss
@@ -81,17 +81,23 @@
       &::after {
         display: none;
       }
-    }
 
-    .modal-mobile-nav {
-      width: 100%;
-      height: 5.6rem;
-      border-bottom: 0.1rem solid $opacity-white-10;
-    }
+      .modal-inner {
+        height: 100%;
+      }
 
-    .modal-header-title {
-      @include responsive(T) {
+      .modal-mobile-nav {
+        width: 100%;
+        height: 5.6rem;
+        border-bottom: 0.1rem solid $opacity-white-10;
+      }
+
+      .modal-header-title {
         padding-top: 2.4rem;
+      }
+
+      .modal-content {
+        height: 100%;
       }
     }
   }

--- a/src/components/commons/modals/CommonModal.module.scss
+++ b/src/components/commons/modals/CommonModal.module.scss
@@ -66,6 +66,41 @@
   &-content {
     width: 100%;
   }
+
+  &.responsive {
+    @include responsive(T) {
+      position: fixed;
+      inset: 0;
+
+      width: 100vw;
+      max-height: 100vh;
+
+      background-color: $black70;
+
+      &::before,
+      &::after {
+        display: none;
+      }
+    }
+
+    .modal-mobile-nav {
+      width: 100%;
+      height: 5.6rem;
+      border-bottom: 0.1rem solid $opacity-white-10;
+    }
+
+    .modal-header-title {
+      @include responsive(T) {
+        padding-top: 2.4rem;
+      }
+    }
+  }
+
+  &:not(.responsive) {
+    .modal-mobile-nav {
+      display: none;
+    }
+  }
 }
 
 .body-open {

--- a/src/components/commons/modals/CommonModal.tsx
+++ b/src/components/commons/modals/CommonModal.tsx
@@ -1,20 +1,27 @@
+import Image from 'next/image';
+
 import { ReactNode, MouseEventHandler } from 'react';
 
 import classNames from 'classnames/bind';
 import ReactModal from 'react-modal';
 
+import { SVGS } from '@/constants';
+
 import styles from './CommonModal.module.scss';
 
 const cx = classNames.bind(styles);
+
+const { url, alt } = SVGS.arrow.chevron;
 
 type CommonModalProps = {
   openModal: boolean;
   onClose: MouseEventHandler<HTMLButtonElement>;
   title: string;
   renderContent: ReactNode;
+  isResponsive?: boolean;
 };
 
-export const CommonModal = ({ openModal, onClose, title, renderContent }: CommonModalProps) => {
+export const CommonModal = ({ openModal, onClose, title, renderContent, isResponsive }: CommonModalProps) => {
   return (
     <ReactModal
       isOpen={openModal}
@@ -22,13 +29,20 @@ export const CommonModal = ({ openModal, onClose, title, renderContent }: Common
       closeTimeoutMS={250}
       shouldCloseOnEsc={true}
       shouldCloseOnOverlayClick={true}
-      className={cx('modal')}
+      className={cx('modal', { responsive: isResponsive })}
       overlayClassName={cx('overlay')}
       bodyOpenClassName={cx('body-open')}
       contentLabel='modal-common'
     >
       <div className={cx('modal-inner')}>
         <header className={cx('modal-header')}>
+          <div className={cx('lg-hidden')}>
+            <nav className={cx('modal-mobile-nav')}>
+              <button onClick={onClose}>
+                <Image src={url} alt={alt} width={48} height={48} />
+              </button>
+            </nav>
+          </div>
           <h2 className={cx('modal-header-title')}>{title}</h2>
         </header>
         <div className={cx('modal-content')}>{renderContent}</div>

--- a/src/components/layout/empty/EmptyCard/EmptyCard.module.scss
+++ b/src/components/layout/empty/EmptyCard/EmptyCard.module.scss
@@ -9,4 +9,8 @@
   background-color: $black70;
   border: 0.1rem dashed $gray50;
   border-radius: 0.8rem;
+
+  &.small {
+    height: 11.2rem;
+  }
 }

--- a/src/components/layout/empty/EmptyCard/index.tsx
+++ b/src/components/layout/empty/EmptyCard/index.tsx
@@ -10,13 +10,14 @@ const cx = classNames.bind(styles);
 
 type EmptyCardProps = {
   text: string;
+  isSmall?: boolean;
 };
 
 const { url, alt } = SVGS.empty;
 
-const EmptyCard = ({ text }: EmptyCardProps) => {
+const EmptyCard = ({ text, isSmall }: EmptyCardProps) => {
   return (
-    <div className={cx('card-empty')}>
+    <div className={cx('card-empty', { small: isSmall })}>
       <Image src={url} alt={alt} width={32} height={32} />
       <div>{text}</div>
     </div>

--- a/src/constants/mockData/reservationDetailMockDataConfirmed.json
+++ b/src/constants/mockData/reservationDetailMockDataConfirmed.json
@@ -1,18 +1,18 @@
 {
   "cursorId": 0,
-  "totalCount": 3,
+  "totalCount": 1,
   "reservations": [
     {
       "id": 1,
-      "nickname": "tester",
+      "nickname": "testerc",
       "userId": 0,
-      "teamId": "test",
+      "teamId": "testerc",
       "activityId": 0,
       "scheduleId": 0,
-      "status": "pending",
+      "status": "confirmed",
       "reviewSubmitted": false,
       "totalPrice": 0,
-      "headCount": 2,
+      "headCount": 1,
       "date": "2024-03-27",
       "startTime": "09:00",
       "endTime": "12:00",

--- a/src/constants/mockData/reservationDetailMockDataDeclined.json
+++ b/src/constants/mockData/reservationDetailMockDataDeclined.json
@@ -1,0 +1,40 @@
+{
+  "cursorId": 0,
+  "totalCount": 2,
+  "reservations": [
+    {
+      "id": 1,
+      "nickname": "testerd",
+      "userId": 0,
+      "teamId": "testd",
+      "activityId": 0,
+      "scheduleId": 0,
+      "status": "declined",
+      "reviewSubmitted": false,
+      "totalPrice": 0,
+      "headCount": 10,
+      "date": "2024-03-27",
+      "startTime": "09:00",
+      "endTime": "12:00",
+      "createdAt": "2024-03-27T02:35:20.905Z",
+      "updatedAt": "2024-03-27T02:35:20.905Z"
+    },
+    {
+      "id": 2,
+      "nickname": "testerd2",
+      "userId": 0,
+      "teamId": "testd2",
+      "activityId": 0,
+      "scheduleId": 0,
+      "status": "declined",
+      "reviewSubmitted": false,
+      "totalPrice": 0,
+      "headCount": 11,
+      "date": "2024-03-27",
+      "startTime": "09:00",
+      "endTime": "12:00",
+      "createdAt": "2024-03-27T02:35:20.905Z",
+      "updatedAt": "2024-03-27T02:35:20.905Z"
+    }
+  ]
+}

--- a/src/constants/mockData/reservationDetailMockDataPending.json
+++ b/src/constants/mockData/reservationDetailMockDataPending.json
@@ -1,0 +1,57 @@
+{
+  "cursorId": 0,
+  "totalCount": 3,
+  "reservations": [
+    {
+      "id": 1,
+      "nickname": "testerp",
+      "userId": 0,
+      "teamId": "testp",
+      "activityId": 0,
+      "scheduleId": 0,
+      "status": "pending",
+      "reviewSubmitted": false,
+      "totalPrice": 0,
+      "headCount": 2,
+      "date": "2024-03-27",
+      "startTime": "09:00",
+      "endTime": "12:00",
+      "createdAt": "2024-03-27T02:35:20.905Z",
+      "updatedAt": "2024-03-27T02:35:20.905Z"
+    },
+    {
+      "id": 2,
+      "nickname": "testerp2",
+      "userId": 0,
+      "teamId": "testp2",
+      "activityId": 0,
+      "scheduleId": 0,
+      "status": "pending",
+      "reviewSubmitted": false,
+      "totalPrice": 0,
+      "headCount": 3,
+      "date": "2024-03-27",
+      "startTime": "09:00",
+      "endTime": "12:00",
+      "createdAt": "2024-03-27T02:35:20.905Z",
+      "updatedAt": "2024-03-27T02:35:20.905Z"
+    },
+    {
+      "id": 3,
+      "nickname": "testerp3",
+      "userId": 0,
+      "teamId": "testp3",
+      "activityId": 0,
+      "scheduleId": 0,
+      "status": "pending",
+      "reviewSubmitted": false,
+      "totalPrice": 0,
+      "headCount": 4,
+      "date": "2024-03-27",
+      "startTime": "09:00",
+      "endTime": "12:00",
+      "createdAt": "2024-03-27T02:35:20.905Z",
+      "updatedAt": "2024-03-27T02:35:20.905Z"
+    }
+  ]
+}

--- a/src/constants/mockData/reservationDetailMockDataPendingNoData.json
+++ b/src/constants/mockData/reservationDetailMockDataPendingNoData.json
@@ -1,0 +1,5 @@
+{
+  "cursorId": 0,
+  "totalCount": 0,
+  "reservations": []
+}

--- a/src/constants/tapOptions.ts
+++ b/src/constants/tapOptions.ts
@@ -1,5 +1,13 @@
+import { ScheduleTabOptions } from '@/types';
+
 export const MYPAGE_TAB_OPTIONS = [
   { id: 'myPost', text: '등록한 게시글' },
   { id: 'myReservation', text: '신청한 예약' },
   { id: 'reservationsStatus', text: '예약 현황' },
+];
+
+export const SCHEDULE_TAB_OPTIONS: ScheduleTabOptions[] = [
+  { id: 'pending', text: '신청' },
+  { id: 'confirmed', text: '승인' },
+  { id: 'declined', text: '거절' },
 ];

--- a/src/constants/tapOptions.ts
+++ b/src/constants/tapOptions.ts
@@ -1,13 +1,5 @@
-import { ScheduleTabOptions } from '@/types';
-
 export const MYPAGE_TAB_OPTIONS = [
   { id: 'myPost', text: '등록한 게시글' },
   { id: 'myReservation', text: '신청한 예약' },
   { id: 'reservationsStatus', text: '예약 현황' },
-];
-
-export const SCHEDULE_TAB_OPTIONS: ScheduleTabOptions[] = [
-  { id: 'pending', text: '신청' },
-  { id: 'confirmed', text: '승인' },
-  { id: 'declined', text: '거절' },
 ];

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,4 +1,4 @@
-import { ReservationResponse } from '@/types';
+import { MyReservationsStatus, MyReservationsStatusKR, ReservationResponse } from '@/types';
 
 export type AvailableSchedule = {
   date: string;
@@ -37,3 +37,8 @@ export type DetailSchedule = {
 };
 
 export type ReservationsByDate = Record<string, MonthlyReservationCount>;
+
+export type ScheduleTabOptions = {
+  id: MyReservationsStatus;
+  text: MyReservationsStatusKR;
+};

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -38,7 +38,8 @@ export type DetailReservationResponse = {
 
 export type ReservationsByDate = Record<string, MonthlyReservationCount>;
 
-export type ScheduleTabOptions = {
+export type StatusTabOptions = {
   id: MyReservationsStatus;
   text: MyReservationsStatusKR;
+  count: number;
 };

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -18,19 +18,19 @@ export type DailyReservationCount = {
   pending: number;
 };
 
-export type MonthlySchedule = {
+export type MonthlyReservationResponse = {
   date: string;
   reservations: MonthlyReservationCount;
 };
 
-export type DailySchedule = {
+export type DailyReservationResponse = {
   scheduleId: number;
   startTime: string;
   endTime: string;
   count: DailyReservationCount;
 };
 
-export type DetailSchedule = {
+export type DetailReservationResponse = {
   cursorId: 0;
   totalCount: 0;
   reservations: Omit<ReservationResponse, 'activity'>[];

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -33,7 +33,11 @@ export type DailyReservationResponse = {
 export type DetailReservationResponse = {
   cursorId: 0;
   totalCount: 0;
-  reservations: Omit<ReservationResponse, 'activity'>[];
+  reservations: ReservationDetail[];
+};
+
+export type ReservationDetail = Omit<ReservationResponse, 'activity'> & {
+  nickname: string;
 };
 
 export type ReservationsByDate = Record<string, MonthlyReservationCount>;

--- a/src/utils/dataMap.ts
+++ b/src/utils/dataMap.ts
@@ -1,6 +1,6 @@
 import { PRICE_TO_POST_TYPES } from '@/constants';
 
-import { MonthlySchedule, ReservationsByDate } from '@/types';
+import { MonthlyReservationResponse, ReservationsByDate } from '@/types';
 
 import { formatCategoryToGameNameKR } from './gameFormatter';
 
@@ -29,7 +29,7 @@ export const splitDescByDelimiter = (inputString: string) => {
   };
 };
 
-export const scheduleListToObjectByDate = (scheduleData: MonthlySchedule[] | undefined) => {
+export const scheduleListToObjectByDate = (scheduleData: MonthlyReservationResponse[] | undefined) => {
   const result: ReservationsByDate = {};
 
   scheduleData?.forEach((schedule) => (result[schedule.date] = schedule.reservations));

--- a/src/utils/dataMap.ts
+++ b/src/utils/dataMap.ts
@@ -1,6 +1,11 @@
 import { PRICE_TO_POST_TYPES } from '@/constants';
 
-import { MonthlyReservationResponse, ReservationsByDate } from '@/types';
+import {
+  DailyReservationCount,
+  DailyReservationResponse,
+  MonthlyReservationResponse,
+  ReservationsByDate,
+} from '@/types';
 
 import { formatCategoryToGameNameKR } from './gameFormatter';
 
@@ -29,10 +34,35 @@ export const splitDescByDelimiter = (inputString: string) => {
   };
 };
 
-export const scheduleListToObjectByDate = (scheduleData: MonthlyReservationResponse[] | undefined) => {
+export const getScheduleByDate = (scheduleData: MonthlyReservationResponse[] | undefined) => {
   const result: ReservationsByDate = {};
 
-  scheduleData?.forEach((schedule) => (result[schedule.date] = schedule.reservations));
+  scheduleData?.forEach((schedule) => {
+    result[schedule.date] = schedule.reservations;
+  });
+
+  return result;
+};
+
+export const getStatusCountByScheduleId = (scheduleData: DailyReservationResponse[] | undefined) => {
+  const result: { [id: number]: DailyReservationCount } = {};
+
+  scheduleData?.forEach((schedule) => {
+    result[schedule.scheduleId] = schedule.count;
+  });
+
+  return result;
+};
+
+export const getScheduleDropdownOption = (scheduleData: DailyReservationResponse[] | undefined) => {
+  const result: { title: string; value: number | string }[] = [];
+
+  scheduleData?.forEach((schedule) => {
+    result.push({
+      title: `${schedule.startTime} - ${schedule.endTime}`,
+      value: schedule.scheduleId,
+    });
+  });
 
   return result;
 };

--- a/src/utils/getDate.ts
+++ b/src/utils/getDate.ts
@@ -126,3 +126,5 @@ export const getMonthString = (month: number) =>
   dayjs()
     .month(month - 1)
     .format('MMMM');
+
+export const getDateStringKR = (date: string) => dayjs(date).format('YYYY년 M월 D일');


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #99 
- close #99 

## 유형

- [X] 기능 구현
- [X] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- [마이페이지] 예약현황 상세 모달 구현

## 설명

### 📌 기능
- 예약 현황이 있는 날짜 클릭 시 해당 날짜에 대한 예약 현황 모달창 뜨도록 구현
- 해당 날짜에 존재하는 예약 시간들 Dropdown 으로 선택 가능하도록 구현
- 선택된 예약 시간별로 신청/거절/승인 상태의 예약 현황 리스트 표시

### 📌 UI
- commonModal 컴포넌트 사용해서 모달 UI 구현
- 신청/거절/승인 탭 별로 카드 컴포넌트 다르게 표시
- 카드 리스트가 모달창 크기를 넘어가면 스크롤되도록 구현

### 🔧 추가 수정사항
- 예약 내역 없으면 EmptyCard 작은버전으로 보이게 하기
- 예약 내역 2개 이상 넘어가면 스크롤 보이도록 하기
- 예약 거절/승인 버튼 누르면 confirm 모달 나오게 하기
- 예약 내역 모달창 태블릿 이하 버전에서 화면에 꽉 차게 나오도록 하기 (CommonModal 수정)
- Dropdown 선택값 길어지면 ellipse (...) 효과 적용

### 남은 작업 (리팩토링때 할것)
- [ ] 모달창 캘린더 안에서 열리도록 수정
- [ ] 태블릿 이하에서 모달 예약 리스트 더 많이 보이게 하기
- [ ] 캘린더 클릭하면 활성화 상태로 유지시키기


## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->

### 📸 디바이스별 스크린샷

![image](https://github.com/sprint-team3/GGF/assets/43297823/1b3a573e-091d-4740-b4f2-78430467e916)

![image](https://github.com/sprint-team3/GGF/assets/43297823/ee305c39-5fd1-41e8-b3c3-5e5ce15ea2b5)

![image](https://github.com/sprint-team3/GGF/assets/43297823/317cd356-1a1b-43fd-88d2-ae365ad04b0f)

![image](https://github.com/sprint-team3/GGF/assets/43297823/cb13cc32-cdca-41cc-a6f4-9cdab1e69ea9)

![image](https://github.com/sprint-team3/GGF/assets/43297823/042381f7-f1f4-4a76-8b48-8fa1286e3209)
