### PR TITLE
Feat[#202]: 모집 상세 페이지 api 연동

### DIFF
--- a/src/apis/activities.ts
+++ b/src/apis/activities.ts
@@ -13,6 +13,11 @@ import { ActivityCreateBody, ReservationCreateBody } from '@/types';
 import instance from './axios';
 
 const Activities = {
+  /**
+   * 체험 상세 조회
+   * @param activityId
+   * @returns
+   */
   get: (activityId: number) => instance.get(`${ACTIVITIES_API}/${activityId}`),
 
   getList: () =>
@@ -25,6 +30,11 @@ const Activities = {
       params: { year, month },
     }),
 
+  /**
+   * 리뷰 목록 조회
+   * @param activityId
+   * @returns
+   */
   getReviewList: (activityId: number) =>
     instance.get(`${ACTIVITIES_API}/${activityId}${REVIEWS_API}`, {
       params: { size: DEFAULT_PAGE_SIZE },

--- a/src/apis/queryFunctions.ts
+++ b/src/apis/queryFunctions.ts
@@ -1,6 +1,24 @@
+import { QueryFunction } from '@tanstack/react-query';
+
 import { MyReservations } from '@/apis/myReservations';
+
+import { ActivityDetailResponse, ReviewResponse } from '@/types';
+
+import Activities from './activities';
 
 export const getMyReservations = async () => {
   const response = await MyReservations.get();
   return response.data.reservations;
+};
+
+export const getActivityDetail: QueryFunction<ActivityDetailResponse, [string, number]> = async ({ queryKey }) => {
+  const postId = queryKey[1];
+  const response = await Activities.get(postId);
+  return response.data;
+};
+
+export const getReviewList: QueryFunction<ReviewResponse, [string, number]> = async ({ queryKey }) => {
+  const postId = queryKey[1];
+  const response = await Activities.getReviewList(postId);
+  return response.data;
 };

--- a/src/apis/queryKeys.ts
+++ b/src/apis/queryKeys.ts
@@ -1,6 +1,8 @@
 export const QUERY_KEYS = {
   activities: {
+    get: 'activityDetail',
     getSchedules: (activityId: number) => ['getSchedules', activityId],
+    getReviewList: 'reviewList',
   },
   myReservations: {
     get: ['myReservation'],

--- a/src/components/postDetail/PostDetailContent/index.tsx
+++ b/src/components/postDetail/PostDetailContent/index.tsx
@@ -19,8 +19,6 @@ import PostDescription from '@/components/postDetail/PostDesciption';
 import PostTitle from '@/components/postDetail/PostTitle';
 import ReservationPanel from '@/components/postDetail/reservationPanel/ReservationPanel';
 import ReviewList from '@/components/postDetail/ReviewList';
-import { POST_DETAIL_DATA } from '@/constants/mockData/postDetail';
-import { REVIEW_LIST_DATA } from '@/constants/mockData/reviewList';
 import { useDeviceType } from '@/hooks/useDeviceType';
 
 import styles from './PostDetailContent.module.scss';
@@ -35,15 +33,36 @@ const PostDetailContent = ({ isLoggedIn }: PostPageProps) => {
   const { postId } = router.query;
   const activityId = Number(postId);
 
-  const { data: postDetailData = POST_DETAIL_DATA } = useQuery({
+  const [isReservationPanelOpen, setIsReservationPanelOpen] = useState(true);
+
+  const handlePanelToggleClick = () => {
+    setIsReservationPanelOpen((prev) => !prev);
+  };
+
+  const currentDeviceType = useDeviceType();
+
+  const isTablet = currentDeviceType === 'Tablet';
+  const isMobile = currentDeviceType === 'Mobile';
+
+  useEffect(() => {
+    if (isTablet || isMobile) {
+      setIsReservationPanelOpen(false);
+    } else {
+      setIsReservationPanelOpen(true);
+    }
+  }, [isTablet, isMobile]);
+
+  const { data: postDetailData } = useQuery({
     queryKey: [QUERY_KEYS.activities.get, activityId],
     queryFn: getActivityDetail,
   });
 
-  const { data: reviewListData = REVIEW_LIST_DATA } = useQuery({
+  const { data: reviewListData } = useQuery({
     queryKey: [QUERY_KEYS.activities.getReviewList, activityId],
     queryFn: getReviewList,
   });
+
+  if (!postDetailData) return;
 
   const {
     title: unrefinedTitle,
@@ -65,27 +84,10 @@ const PostDetailContent = ({ isLoggedIn }: PostPageProps) => {
   const isStrategy = price === 3;
   const isReservationAvailable = isOffline || isOnline;
 
-  const { title } = splitTitleByDelimiter(unrefinedTitle);
+  const { title, MaxCount } = splitTitleByDelimiter(unrefinedTitle);
   const { description, discordLink } = splitDescByDelimiter(unrefinedDescription);
 
-  const [isReservationPanelOpen, setIsReservationPanelOpen] = useState(true);
-
-  const handlePanelToggleClick = () => {
-    setIsReservationPanelOpen((prev) => !prev);
-  };
-
-  const currentDeviceType = useDeviceType();
-
-  const isTablet = currentDeviceType === 'Tablet';
-  const isMobile = currentDeviceType === 'Mobile';
-
-  useEffect(() => {
-    if (isTablet || isMobile) {
-      setIsReservationPanelOpen(false);
-    } else {
-      setIsReservationPanelOpen(true);
-    }
-  }, [isTablet, isMobile]);
+  if (!reviewListData) return;
 
   return (
     <>
@@ -118,7 +120,7 @@ const PostDetailContent = ({ isLoggedIn }: PostPageProps) => {
                   <ReservationPanel
                     isLoggedIn={isLoggedIn}
                     activityId={activityId}
-                    maxCount={3}
+                    maxCount={+MaxCount}
                     onClick={handlePanelToggleClick}
                   />
                 )}

--- a/src/components/postDetail/PostDetailContent/index.tsx
+++ b/src/components/postDetail/PostDetailContent/index.tsx
@@ -30,7 +30,7 @@ const cx = classNames.bind(styles);
 const nickname = '주인장';
 const email = 'test@test.com';
 
-const PostContent = ({ isLoggedIn }: PostPageProps) => {
+const PostDetailContent = ({ isLoggedIn }: PostPageProps) => {
   const router = useRouter();
   const { postId } = router.query;
   const activityId = Number(postId);
@@ -132,4 +132,4 @@ const PostContent = ({ isLoggedIn }: PostPageProps) => {
   );
 };
 
-export default PostContent;
+export default PostDetailContent;

--- a/src/constants/mockData/postDetail.ts
+++ b/src/constants/mockData/postDetail.ts
@@ -10,7 +10,7 @@ export const POST_DETAIL_DATA = {
   price: 1,
   address: '서울특별시 강남구 테헤란로 427',
   bannerImageUrl: IMAGE_LIST[0],
-  subImageUrls: [
+  subImages: [
     {
       id: 1,
       imageUrl: IMAGE_LIST[1],

--- a/src/pages/[game]/[postId]/index.tsx
+++ b/src/pages/[game]/[postId]/index.tsx
@@ -7,7 +7,7 @@ import { QUERY_KEYS } from '@/apis/queryKeys';
 import { getAuthCookie, queryClient } from '@/utils';
 
 import Layout from '@/components/layout/Layout';
-import PostConent from '@/components/postDetail/PostDetailContent';
+import PostDetailContent from '@/components/postDetail/PostDetailContent';
 
 export function getServerSideProps(context: GetServerSidePropsContext) {
   const { accessToken } = getAuthCookie(context);
@@ -49,7 +49,7 @@ export type PostPageProps = {
 };
 
 const PostPage = ({ isLoggedIn }: PostPageProps) => {
-  return <PostConent isLoggedIn={isLoggedIn} />;
+  return <PostDetailContent isLoggedIn={isLoggedIn} />;
 };
 
 export default PostPage;

--- a/src/pages/[game]/[postId]/index.tsx
+++ b/src/pages/[game]/[postId]/index.tsx
@@ -1,8 +1,55 @@
+import { GetServerSidePropsContext } from 'next';
+
+import { dehydrate } from '@tanstack/react-query';
+
+import { getActivityDetail, getReviewList } from '@/apis/queryFunctions';
+import { QUERY_KEYS } from '@/apis/queryKeys';
+import { getAuthCookie, queryClient } from '@/utils';
+
 import Layout from '@/components/layout/Layout';
 import PostConent from '@/components/postDetail/PostDetailContent';
 
-const PostPage = () => {
-  return <PostConent />;
+export function getServerSideProps(context: GetServerSidePropsContext) {
+  const { accessToken } = getAuthCookie(context);
+  const isLoggedIn = !!accessToken;
+
+  const { params } = context;
+  const postId = Number(params?.postId);
+  const game = params?.game;
+
+  if (!postId) {
+    return {
+      redirect: {
+        destination: `/${game}`,
+        permanent: false,
+      },
+    };
+  }
+
+  queryClient.prefetchQuery({
+    queryKey: [QUERY_KEYS.activities.get, postId],
+    queryFn: getActivityDetail,
+  });
+
+  queryClient.prefetchQuery({
+    queryKey: [QUERY_KEYS.activities.getReviewList, postId],
+    queryFn: getReviewList,
+  });
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+      isLoggedIn,
+    },
+  };
+}
+
+export type PostPageProps = {
+  isLoggedIn: boolean;
+};
+
+const PostPage = ({ isLoggedIn }: PostPageProps) => {
+  return <PostConent isLoggedIn={isLoggedIn} />;
 };
 
 export default PostPage;

--- a/src/types/myActivities.ts
+++ b/src/types/myActivities.ts
@@ -40,6 +40,23 @@ export type ActivityResponse = {
   updatedAt: string;
 };
 
+export type ActivityDetailResponse = {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  subImages: { id: number; imageUrl: string }[];
+  schedules: { id: number; date: string; startTime: string; endTime: string }[];
+  reviewCount: number;
+  rating: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type ReviewResponse = {
   averageRating: number;
   totalCount: number;


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #202 
- close #202

## 유형

- [x] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

## 설명

### 📌 기능
### 🔎 pages/[game]/[postId]/index.tsx
- SSR + 리액트쿼리 사용했습니다.
- 액세스토큰 확인해서 로그인 상태 확인 후 자식 컴포넌트(예약 컴포넌트)로 전달합니다.
- 존재하지 않는 postId로 접근할 경우 게임 카테고리 리스트로 리다이렉트합니다.
- 모집 상세 데이터 조회, 리뷰 리스트 데이터 조회하는 prefetchQuery를 사용합니다.

### 🔎 PostDetailContent
- useQuery로 상위 페이지에서 refetch한 데이터를 가져옵니다.