### PR TITLE
Feat[#224]: 마이페이지/신청한 예약 api 연동

### DIFF
--- a/src/components/commons/buttons/CardButton.module.scss
+++ b/src/components/commons/buttons/CardButton.module.scss
@@ -11,7 +11,7 @@
 
   span {
     display: inline-block;
-    width: 4.8rem;
+    width: 6rem;
   }
 }
 
@@ -45,4 +45,10 @@
   }
 
   color: $red;
+}
+
+.btn-color-gray {
+  color: $gray40;
+  background-color: transparent;
+  border: 0.1rem solid $gray50;
 }

--- a/src/components/commons/buttons/CardButton.tsx
+++ b/src/components/commons/buttons/CardButton.tsx
@@ -8,8 +8,8 @@ const cx = classNames.bind(styles);
 
 type CardButton = {
   children: string;
-  onClick: MouseEventHandler<HTMLButtonElement>;
-  color?: 'yellow' | 'red';
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  color?: 'yellow' | 'red' | 'gray';
 };
 
 export const CardButton = ({ children, onClick, color = 'yellow' }: CardButton) => {

--- a/src/components/commons/cards/ReservedCard.module.scss
+++ b/src/components/commons/cards/ReservedCard.module.scss
@@ -1,4 +1,11 @@
 .card {
+  @include responsive(PC) {
+    &:hover {
+      background-color: $black60;
+      border-radius: 0.8rem;
+    }
+  }
+
   position: relative;
 
   width: 100%;
@@ -7,15 +14,6 @@
   border-radius: 0.8rem;
 
   transition: $base-transition;
-
-  &:hover {
-    @include responsive(M) {
-      background-color: $card-background;
-    }
-
-    background-color: $black60;
-    border-radius: 0.8rem;
-  }
 
   &-content {
     @include column-flexbox(start, start, 0.4rem);

--- a/src/components/commons/cards/ReservedCard.tsx
+++ b/src/components/commons/cards/ReservedCard.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 
 import { MyReservations } from '@/apis/myReservations';
+import { QUERY_KEYS } from '@/apis/queryKeys';
 import { SVGS } from '@/constants';
 import { isExpirationDate, getFormatDate } from '@/utils';
 
@@ -28,6 +29,7 @@ export type ReservedCardProps = {
   reservationId: number;
   path: string;
   status: MyReservationsStatus | string;
+  reviewSubmitted: boolean;
   postType: ReservedPostTypesEN | string;
   title: string;
   address: string;
@@ -42,6 +44,7 @@ export const ReservedCard = ({
   reservationId,
   path,
   status,
+  reviewSubmitted,
   postType,
   title,
   address,
@@ -54,14 +57,14 @@ export const ReservedCard = ({
   const { multiState, toggleClick } = useMultiState(['cancelReservationModal', 'submitReviewModal']);
   const isOffline = postType === 'offline';
   const isPending = status === 'pending';
-  const isReviewWritable = status === 'completed' && isExpirationDate(date, endTime);
+  const isReviewWritable = status === 'completed' && isExpirationDate(date, endTime) && !reviewSubmitted;
   const MyReservationDate = `${date} | ${startTime}-${endTime}`;
 
   const queryClient = useQueryClient();
   const { mutate: cancelReservationMutation } = useMutation({
     mutationFn: MyReservations.cancel,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myReservations', reservationId] });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.myReservations.get });
     },
   });
 
@@ -112,6 +115,7 @@ export const ReservedCard = ({
             {isReviewWritable && (
               <CardButton onClick={(event) => handleButtonClick(event, 'submitReviewModal')}>리뷰</CardButton>
             )}
+            {reviewSubmitted && <CardButton color='gray'>리뷰 완료</CardButton>}
           </div>
         </Link>
       </article>

--- a/src/components/mypage/MyReservations/ReservedTabContent/index.tsx
+++ b/src/components/mypage/MyReservations/ReservedTabContent/index.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react';
 
+import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 
-import { MY_RESERVATIONS_STATUS_FILTERS, SORT_OPTIONS } from '@/constants';
+import { getMyReservations } from '@/apis/queryFunctions';
+import { QUERY_KEYS } from '@/apis/queryKeys';
+import { GAME_NAME_KR_TO_PATH_NAME, MY_RESERVATIONS_STATUS_FILTERS, SORT_OPTIONS } from '@/constants';
 import { formatStatusToKR, splitTitleByDelimiter } from '@/utils';
 import { getPostPageSize } from '@/utils/getPageSize';
 
@@ -11,23 +14,14 @@ import Dropdown from '@/components/commons/Dropdown';
 import Filter from '@/components/commons/Filter';
 import Pagination from '@/components/commons/Pagination';
 import EmptyCard from '@/components/layout/empty/EmptyCard';
-import myReservationsMockData from '@/constants/mockData/myReservationsMockData.json';
 import { useDeviceType } from '@/hooks/useDeviceType';
 import useProcessedDataList from '@/hooks/useProcessedDataList';
 
-import { MyReservationsResponse, ReservationResponse, SortOption, Order } from '@/types';
+import { ReservationResponse, SortOption, Order } from '@/types';
 
 import styles from './ReservedTabContent.module.scss';
 
 const cx = classNames.bind(styles);
-
-const myReservationsData: MyReservationsResponse = {
-  cursorId: 0,
-  totalCount: 0,
-  reservations: myReservationsMockData,
-};
-
-const { reservations: initialDataList } = myReservationsData;
 
 const initialFilter = {
   status: MY_RESERVATIONS_STATUS_FILTERS[0].id,
@@ -40,6 +34,8 @@ const initialSortOption: SortOption<ReservationResponse> = {
 };
 
 const ReservedTabContent = () => {
+  const { data: initialDataList } = useQuery({ queryKey: QUERY_KEYS.myReservations.get, queryFn: getMyReservations });
+
   const [page, setPage] = useState(1);
   const [selectFilter, setSelectFilter] = useState(initialFilter);
   const [sortOption, setSortOption] = useState(initialSortOption);
@@ -86,8 +82,9 @@ const ReservedTabContent = () => {
               <li key={card.id}>
                 <ReservedCard
                   reservationId={card.id}
-                  path='/'
+                  path={`/${GAME_NAME_KR_TO_PATH_NAME[category]}/${card.activity.id}`}
                   status={card.status}
+                  reviewSubmitted={card.reviewSubmitted}
                   postType={postType}
                   title={title}
                   address={address}

--- a/src/constants/games.ts
+++ b/src/constants/games.ts
@@ -30,3 +30,10 @@ export const GAME_FILTERS = [
   { id: '관광', text: '오버워치 2' },
   { id: '웰빙', text: '마인크래프트' },
 ];
+
+export const GAME_NAME_KR_TO_PATH_NAME: Record<string, string> = {
+  리그오브레전드: 'league-of-legends',
+  배틀그라운드: 'battlegrounds',
+  '오버워치 2': 'overwatch-2',
+  마인크래프트: 'minecraft',
+};

--- a/src/stories/ReservedCard.stories.ts
+++ b/src/stories/ReservedCard.stories.ts
@@ -15,6 +15,7 @@ export const Example: Story = {
     reservationId: 0,
     path: '/',
     status: 'pending',
+    reviewSubmitted: false,
     postType: 'offline',
     title: '[PC방 대회]리그 오브 레전드 개발자들의 PC방 습격!',
     address: '강남 SBXG 포탈 PC방',


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #224 
- close #224

## 유형

- [x] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 마이페이지 신청한 예약 API 연동했습니다.
- [GET] 내 예약 리스트 조회
- [PATCH] 내 예약 취소
- [POST] 내 예약 리뷰 작성

## 설명

### 📌 기능
- 마이페이지로 이동 시 `토큰 유무`를 확인하고, 토큰이 없는 경우 `랜딩 페이지`로 `리다이렉트`합니다.
- 데이터 조회에 SSR과 react-query를 사용합니다.
- 리뷰 작성 조건: 예약 상태가 `completed`이고, 예약 날짜가 지난 경우, 예약 제출 현황이 `false`인 경우 리뷰 버튼이 표시됩니다.
- 리뷰를 작성한 후에는 `리뷰 완료` 버튼으로 변경됩니다.
- 예약은 `pending` 상태일 때만 취소할 수 있습니다.
- 예약이 확정된 이후에는 취소할 수 없습니다.

### 📌 UI
- PC 디바이스 이하에서는 예약 카드의 hover 효과를 제거했습니다.
- 리뷰 완료 버튼 스타일을 추가하였습니다.

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 📸 디바이스별 스크린샷

<img width="1912" alt="image" src="https://github.com/sprint-team3/GGF/assets/77719310/0a251845-b34a-40eb-a6d5-8c5e1fcf9321">
