### PR TITLE
Feat[#228] : Header user data와 alarm data 조회 연결

### DIFF
--- a/src/apis/queryFunctions.ts
+++ b/src/apis/queryFunctions.ts
@@ -12,6 +12,8 @@ import {
 } from '@/types';
 
 import Activities from './activities';
+import { MyNotifications } from './myNotifications';
+import { Users } from './users';
 
 export const getMyReservations = async () => {
   const response = await MyReservations.get();
@@ -71,4 +73,14 @@ export const deleteMyActivities = async (activityId: number) => {
 export const editMyActivities = async (activityId: number, myActivities: MyActivitiesBody) => {
   const response = await MyActivities.edit(activityId, myActivities);
   return response.status;
+};
+
+export const getUser = async () => {
+  const response = await Users.get();
+  return response.data;
+};
+
+export const getMyNotifications = async () => {
+  const response = await MyNotifications.get();
+  return response.data;
 };

--- a/src/apis/queryKeys.ts
+++ b/src/apis/queryKeys.ts
@@ -29,4 +29,12 @@ export const QUERY_KEYS = {
       status,
     ],
   },
+
+  users: {
+    get: 'users',
+  },
+
+  myNotifications: {
+    get: 'alarms',
+  },
 };

--- a/src/components/layout/header/Header/index.tsx
+++ b/src/components/layout/header/Header/index.tsx
@@ -73,9 +73,9 @@ const Header = () => {
     useUserStore.setState({ user: userData.data });
   }
 
-  if (!userData) return;
-
-  const { email, nickname, profileImageUrl } = userData;
+  const email = userData?.email;
+  const nickname = userData?.nickname;
+  const profileImageUrl = userData?.profileImageUrl;
 
   return (
     <>

--- a/src/components/layout/header/HeaderProfile/HeaderProfile.module.scss
+++ b/src/components/layout/header/HeaderProfile/HeaderProfile.module.scss
@@ -3,6 +3,6 @@
 
   &-container-inner {
     @include flexbox($gap: 0.2rem);
-    @include text-style-quantico(16, $white, regular, normal);
+    @include text-style(16, $white);
   }
 }

--- a/src/components/layout/header/buttons/HeaderSignButton.module.scss
+++ b/src/components/layout/header/buttons/HeaderSignButton.module.scss
@@ -1,0 +1,54 @@
+%btn-base {
+  width: 8.8rem;
+  height: 4rem;
+  padding: 0.8rem;
+
+  border-radius: 0.6rem;
+
+  transition: $base-transition;
+}
+
+%text-base {
+  display: block;
+  width: 7.2rem;
+}
+
+.signin-btn {
+  @extend %btn-base;
+
+  @include text-style-quantico(14, $white, bold, normal);
+
+  background: $opacity-white-20;
+
+  .text {
+    @extend %text-base;
+
+    @include text-style-quantico(14, $white, bold, normal);
+
+    @include responsive(PC) {
+      &:hover {
+        color: $primary;
+      }
+    }
+
+    transition: $base-transition;
+  }
+}
+
+.signup-btn {
+  @extend %btn-base;
+
+  @include responsive(PC) {
+    &:hover {
+      border-color: $primary;
+    }
+  }
+
+  border: 0.1rem solid $opacity-white-20;
+
+  .text {
+    @extend %text-base;
+
+    @include text-style-quantico(14, $white, bold, normal);
+  }
+}

--- a/src/components/layout/header/buttons/HeaderSigninButton.tsx
+++ b/src/components/layout/header/buttons/HeaderSigninButton.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+import classNames from 'classnames/bind';
+
+import { PAGE_PATHS } from '@/constants';
+
+import styles from './HeaderSignButton.module.scss';
+
+const cx = classNames.bind(styles);
+
+export const HeaderSigninButton = () => {
+  return (
+    <Link href={PAGE_PATHS.signin}>
+      <button className={cx('signin-btn')}>
+        <span className={cx('text')}>SIGNIN</span>
+      </button>
+    </Link>
+  );
+};

--- a/src/components/layout/header/buttons/HeaderSignupButton.tsx
+++ b/src/components/layout/header/buttons/HeaderSignupButton.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+import classNames from 'classnames/bind';
+
+import { PAGE_PATHS } from '@/constants';
+
+import styles from './HeaderSignButton.module.scss';
+
+const cx = classNames.bind(styles);
+
+export const HeaderSignupButton = () => {
+  return (
+    <Link href={PAGE_PATHS.signup}>
+      <button className={cx('signup-btn')}>
+        <div className={cx('text')}>SIGNUP</div>
+      </button>
+    </Link>
+  );
+};

--- a/src/components/layout/header/buttons/index.ts
+++ b/src/components/layout/header/buttons/index.ts
@@ -1,0 +1,2 @@
+export * from './HeaderSigninButton';
+export * from './HeaderSignupButton';

--- a/src/hooks/useAlarmData.ts
+++ b/src/hooks/useAlarmData.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMyNotifications } from '@/apis/queryFunctions';
+import { QUERY_KEYS } from '@/apis/queryKeys';
+
+const useAlarmData = (accessToken: string) => {
+  const {
+    data: alarmData,
+    isSuccess,
+    isError,
+  } = useQuery({
+    queryKey: [QUERY_KEYS.myNotifications.get],
+    queryFn: getMyNotifications,
+    enabled: !!accessToken,
+  });
+
+  return { alarmData, isSuccess, isError };
+};
+
+export default useAlarmData;

--- a/src/hooks/useUserData.ts
+++ b/src/hooks/useUserData.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getUser } from '@/apis/queryFunctions';
+import { QUERY_KEYS } from '@/apis/queryKeys';
+
+const useUserData = (accessToken: string) => {
+  const {
+    data: userData,
+    isSuccess,
+    isError,
+  } = useQuery({
+    queryKey: [QUERY_KEYS.users.get, accessToken],
+    queryFn: getUser,
+    enabled: !!accessToken,
+  });
+
+  return { userData, isSuccess, isError };
+};
+
+export default useUserData;

--- a/src/styles/mixins/_text-style.scss
+++ b/src/styles/mixins/_text-style.scss
@@ -102,6 +102,13 @@
   line-height: 1.4rem;
 }
 
+@mixin quantico-14() {
+  @extend %quantico;
+
+  font-size: $font-size-14;
+  line-height: 2.4rem;
+}
+
 @mixin quantico-16() {
   @extend %quantico;
 
@@ -161,6 +168,10 @@
 @mixin text-style-quantico($size, $color: false, $weight: 'bold', $style: 'italic') {
   @if $size == 12 {
     @include quantico-12;
+  }
+
+  @if $size == 14 {
+    @include quantico-14;
   }
 
   @if $size == 16 {

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,8 +1,8 @@
 export type ProfileImage = string | null;
 
-export type UserProfile = Pick<Users, 'email' | 'nickname' | 'profileImageUrl'>;
+export type UserProfile = Pick<UsersResponse, 'email' | 'nickname' | 'profileImageUrl'>;
 
-export type Users = {
+export type UsersResponse = {
   id: number;
   email: string;
   nickname: string;

--- a/src/utils/checkAuth.ts
+++ b/src/utils/checkAuth.ts
@@ -56,3 +56,15 @@ export const requiresLogin = async (
     }
   }
 };
+
+export const setAuthorization = (accessToken: string) => {
+  ssrInstance.interceptors.request.use(
+    (config) => {
+      config.headers['Authorization'] = `Bearer ${accessToken}`;
+      return config;
+    },
+    (error) => {
+      Promise.reject(error);
+    },
+  );
+};

--- a/src/utils/cookieUtils.ts
+++ b/src/utils/cookieUtils.ts
@@ -25,3 +25,10 @@ export const getAuthCookie = (context: GetServerSidePropsContext) => {
   const refreshToken = cookies?.refreshToken;
   return { accessToken, refreshToken };
 };
+
+export const getCSRCookie = () => {
+  const cookies = parseCookies();
+  const accessToken = cookies?.accessToken;
+  const refreshToken = cookies?.refreshToken;
+  return { accessToken, refreshToken };
+};


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #228 
- close #228

## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

## 설명

### 📌 기능
### 💁 HeaderSigninButton & HeaderSignupButton
- 비로그인 상태에 Header에 프로필 대신 보여집니다.
- Link 기능이 있습니다.
- PC 사이즈에서만 hover 효과있습니다.

### 💁 hooks/useUserData.ts
- 액세스토큰이 있을 시에만 useQuery로 user data를 가져옵니다.
- 조건부로 실행되어야 하기에 hook 으로 분리했습니다.

### 💁 hooks/useAlarmData.ts 
- 액세스토큰이 있을 시에만 useQuery로 alarm data를 가져옵니다.
- 조건부로 실행되어야 하기에 hook 으로 분리했습니다.

### 💁 cookieUtils.ts의 getCSRCookie
- CSR 쿠키에서 토큰을 가져옵니다.

### 💁 checkAuth.ts의 setAuthorization
- SSR instance의 authorization header를 accessToken으로 설정합니다.

### 🎥 모션 영상

https://github.com/sprint-team3/GGF/assets/92169354/f8258379-d67a-4436-9ff7-965e713dc603

