### PR TITLE
Feat[#204] : account 페이지 api 연동

### DIFF
--- a/src/apis/queryKeys.ts
+++ b/src/apis/queryKeys.ts
@@ -32,7 +32,7 @@ export const QUERY_KEYS = {
 
   users: {
     get: 'users',
-    edit: 'myInfomations',
+    edit: (userId: number) => ['myInfomations', userId],
   },
 
   myNotifications: {

--- a/src/apis/queryKeys.ts
+++ b/src/apis/queryKeys.ts
@@ -32,6 +32,7 @@ export const QUERY_KEYS = {
 
   users: {
     get: 'users',
+    edit: 'myInfomations',
   },
 
   myNotifications: {

--- a/src/apis/users.ts
+++ b/src/apis/users.ts
@@ -9,16 +9,25 @@ export const Users = {
 
   get: () => instance.get(`${USERS_API}${ME_API}`),
 
+  /**
+   * 내 정보 수정
+   */
   edit: (value: UsersEditParams) => instance.patch(`${USERS_API}${ME_API}`, value),
 
-  createImageUrl: (image: string) => {
+  /**
+   * 프로필 이미지 url 생성
+   * @param image
+   * @returns
+   */
+  createImageUrl: async (image: File) => {
     const formData = new FormData();
     formData.append('image', image);
 
-    instance.post(`${USERS_API}${ME_API}${IMAGE_API}`, formData, {
+    const response = await instance.post(`${USERS_API}${ME_API}${IMAGE_API}`, formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
     });
+    return response;
   },
 };

--- a/src/apis/users/schema.ts
+++ b/src/apis/users/schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+import { ERROR_MESSAGE, INPUT_NAMES, REGEX } from '@/constants';
+
+const { profileImageUrl, nickname, password, passwordConfirm, image } = INPUT_NAMES;
+
+export const ImageSchema = z.object({
+  [image]: z.instanceof(File),
+});
+
+export const ProfileSchema = z.object({
+  email: z.string().optional(),
+  [profileImageUrl]: z.string().nullable(),
+  [nickname]: z.string().min(1, { message: ERROR_MESSAGE.nickname.min }),
+});
+
+export const PasswordSchema = z
+  .object({
+    [password]: z
+      .string()
+      .min(8, { message: ERROR_MESSAGE.password.min })
+      .regex(REGEX.password, ERROR_MESSAGE.password.regex),
+    [passwordConfirm]: z.string(),
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    path: [passwordConfirm],
+    message: ERROR_MESSAGE.password.refine,
+  });

--- a/src/components/AccountForm/index.tsx
+++ b/src/components/AccountForm/index.tsx
@@ -116,7 +116,7 @@ const AccountForm = () => {
   };
 
   const { mutate: profileImageMutation } = useMutation({
-    mutationFn: (value: File) => Users.createImageUrl(value),
+    mutationFn: Users.createImageUrl,
     onSuccess(data) {
       const { profileImageUrl } = data.data;
       setProfileFormValue('profileImageUrl', profileImageUrl);

--- a/src/components/AccountForm/index.tsx
+++ b/src/components/AccountForm/index.tsx
@@ -17,8 +17,6 @@ import { ConfirmModal, ModalButton } from '@/components/commons/modals';
 import useMultiState from '@/hooks/useMultiState';
 import useUserStore from '@/stores/useUserStore';
 
-import { UsersEditParams } from '@/types';
-
 import styles from './AccountForm.module.scss';
 
 const cx = classNames.bind(styles);
@@ -128,7 +126,7 @@ const AccountForm = () => {
   const { setUserData } = useUserStore();
 
   const { mutate: profileMutation } = useMutation({
-    mutationFn: (value: UsersEditParams) => Users.edit(value),
+    mutationFn: Users.edit,
     mutationKey: [QUERY_KEYS.users.edit, userId],
     onSuccess(data) {
       const { profileImageUrl } = data.data;
@@ -139,7 +137,7 @@ const AccountForm = () => {
   });
 
   const { mutate: passwordMutation } = useMutation({
-    mutationFn: (value: UsersEditParams) => Users.edit(value),
+    mutationFn: Users.edit,
     onSuccess() {
       toggleClick('saveAlertModal');
     },

--- a/src/components/auth/SigninForm/index.tsx
+++ b/src/components/auth/SigninForm/index.tsx
@@ -46,12 +46,13 @@ const SigninForm = () => {
   const { isVisible: is404Visible, handleToggleClick: toggle404Click } = useToggleButton();
   const { isVisible: is400Visible, handleToggleClick: toggle400Click } = useToggleButton();
 
+  const { setUserData } = useUserStore();
   const { mutate: signinMutation } = useMutation({
     mutationFn: (value: Account) => Auth.signin(value),
     onSuccess(data) {
       const { accessToken, refreshToken, user } = data.data;
       setAuthCookie(null, accessToken, refreshToken);
-      useUserStore.setState({ user: user });
+      setUserData(user);
       redirectToPage(PAGE_PATHS.mainList);
     },
     onError: (error) => {

--- a/src/components/layout/header/Header/index.tsx
+++ b/src/components/layout/header/Header/index.tsx
@@ -69,13 +69,15 @@ const Header = () => {
 
   const { userData, isSuccess: isUserDataSuccess } = useUserData(accessToken);
 
-  if (isUserDataSuccess) {
-    useUserStore.setState({ user: userData.data });
-  }
+  const { setUserData } = useUserStore();
 
   const email = userData?.email;
   const nickname = userData?.nickname;
   const profileImageUrl = userData?.profileImageUrl;
+
+  useEffect(() => {
+    setUserData(userData);
+  }, [userData]);
 
   return (
     <>

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,7 +1,15 @@
 import { create } from 'zustand';
 
-const useUserStore = create(() => ({
-  user: null,
+import { UsersResponse } from '@/types';
+
+type UserStoreState = {
+  userData: UsersResponse | null;
+  setUserData: (newData: UsersResponse) => void;
+};
+
+const useUserStore = create<UserStoreState>((set) => ({
+  userData: null,
+  setUserData: (newData: UsersResponse) => set({ userData: newData }),
 }));
 
 export default useUserStore;

--- a/src/utils/signout.ts
+++ b/src/utils/signout.ts
@@ -5,5 +5,5 @@ import useUserStore from '@/stores/useUserStore';
 export const signout = () => {
   destroyCookie(null, 'accessToken');
   destroyCookie(null, 'refreshToken');
-  useUserStore.setState({ user: null });
+  useUserStore.setState({ userData: null });
 };


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #204 
- close #204

## 유형

- [x] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

## 설명

### 📌 기능
### 💁 프로필 변경
1. 프로필 초기화가 가능합니다.
2. 프로필 이미지 변경이 가능합니다.
4. 닉네임 변경이 가능합니다.
5. 프로필 이미지나 닉네임의 변경이 일어나지 않으면 저장 버튼이 활성화되지 않습니다.
6. 유저 데이터를 useUserStore에서 가져와서 보여줍니다.

### 💁 비밀번호 변경
1. 비밀번호 변경이 가능합니다.
2. 비밀번호 입력이 일어나지 않으면 저장 버튼이 활성화되지 않습니다.

### 🎥 모션 영상

### 📸 디바이스별 스크린샷

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
