### PR TITLE
Feat[#135]: 마이페이지 예약 현황 API 연동

### DIFF
--- a/src/apis/myActivities.ts
+++ b/src/apis/myActivities.ts
@@ -33,7 +33,7 @@ export const MyActivities = {
       },
     }),
 
-  getHourlyReservationList: (activityId: number, scheduleId: number, status: ReservationStatus) =>
+  getDetailReservationList: (activityId: number, scheduleId: number, status: ReservationStatus) =>
     instance.get(`${MY_ACTIVITIES_API}/${activityId}${RESERVATIONS_API}`, {
       params: {
         size: DEFAULT_PAGE_SIZE,

--- a/src/apis/queryFunctions.ts
+++ b/src/apis/queryFunctions.ts
@@ -54,12 +54,12 @@ export const getMyActivitiesDailyReservationList = async (activityId: number, da
   return response.data;
 };
 
-export const getMyActivitiesHourlyReservationList = async (
+export const getMyActivitiesDetailReservationList = async (
   activityId: number,
   scheduleId: number,
   status: ReservationStatus,
 ) => {
-  const response = await MyActivities.getHourlyReservationList(activityId, scheduleId, status);
+  const response = await MyActivities.getDetailReservationList(activityId, scheduleId, status);
   return response.data;
 };
 

--- a/src/apis/queryFunctions.ts
+++ b/src/apis/queryFunctions.ts
@@ -6,10 +6,10 @@ import { MyReservations } from '@/apis/myReservations';
 import {
   ActivityDetailResponse,
   ReviewResponse,
-  EditReservationStatusBody,
   MyActivitiesBody,
   ReservationStatus,
   ActivitiesResponse,
+  changeStatusMutationParams,
 } from '@/types';
 
 import Activities from './activities';
@@ -63,11 +63,11 @@ export const getMyActivitiesDetailReservationList = async (
   return response.data;
 };
 
-export const editMyActivitiesReservationStatus = async (
-  activityId: number,
-  reservationId: number,
-  status: EditReservationStatusBody,
-) => {
+export const editMyActivitiesReservationStatus = async ({
+  activityId,
+  reservationId,
+  status,
+}: changeStatusMutationParams) => {
   const response = await MyActivities.editReservationStatus(activityId, reservationId, status);
   return response.status;
 };

--- a/src/apis/queryKeys.ts
+++ b/src/apis/queryKeys.ts
@@ -23,7 +23,7 @@ export const QUERY_KEYS = {
       month,
     ],
     getDailyReservationList: (activityId: number, date: string) => ['myActivities', activityId, date],
-    getHourlyReservationList: (activityId: number, scheduleId: number, status: ReservationStatus) => [
+    getDetailReservationList: (activityId: number, scheduleId: number, status: ReservationStatus) => [
       'myActivities',
       activityId,
       scheduleId,

--- a/src/components/calendar/ModalCard/index.tsx
+++ b/src/components/calendar/ModalCard/index.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames/bind';
 import Badge from '@/components/commons/Badge';
 import { BaseButton } from '@/components/commons/buttons';
 
-import { MyReservationsStatus } from '@/types';
+import { ReservationStatus } from '@/types';
 
 import styles from './ModalCard.module.scss';
 
@@ -14,7 +14,7 @@ const cx = classNames.bind(styles);
 type ModalCardProps = {
   nickName: string;
   headCount: number;
-  status: MyReservationsStatus;
+  status: ReservationStatus;
   onClickButton: (text: string) => void;
 };
 

--- a/src/components/calendar/ModalCard/index.tsx
+++ b/src/components/calendar/ModalCard/index.tsx
@@ -12,13 +12,23 @@ import styles from './ModalCard.module.scss';
 const cx = classNames.bind(styles);
 
 type ModalCardProps = {
+  scheduleId: number;
+  reservationId: number;
   nickName: string;
   headCount: number;
   status: ReservationStatus;
-  onClickButton: (text: string) => void;
+  onClickButton: (scheduleId: number, reservationId: number, status: ReservationStatus) => void;
 };
 
-const ModalCard = ({ nickName, headCount, status, onClickButton }: ModalCardProps) => {
+const ModalCard = ({ scheduleId, reservationId, nickName, headCount, status, onClickButton }: ModalCardProps) => {
+  const handleClickDeclineButton = () => {
+    onClickButton(scheduleId, reservationId, 'declined');
+  };
+
+  const handleClickConfirmButton = () => {
+    onClickButton(scheduleId, reservationId, 'confirmed');
+  };
+
   return (
     <div className={cx('modal-card-container')}>
       <div className={cx('modal-card-text')}>
@@ -34,10 +44,10 @@ const ModalCard = ({ nickName, headCount, status, onClickButton }: ModalCardProp
       <div className={cx('modal-card-button')}>
         {status === 'pending' ? (
           <Fragment>
-            <BaseButton theme='outline' size='small' onClick={() => onClickButton('거절')}>
+            <BaseButton theme='outline' size='small' onClick={handleClickDeclineButton}>
               거절
             </BaseButton>
-            <BaseButton theme='ghost' size='small' onClick={() => onClickButton('승인')}>
+            <BaseButton theme='ghost' size='small' onClick={handleClickConfirmButton}>
               승인
             </BaseButton>
           </Fragment>

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -3,7 +3,7 @@ import { MouseEventHandler, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 
-import { getMyActivitiesDailyReservationList, getMyActivitiesHourlyReservationList } from '@/apis/queryFunctions';
+import { getMyActivitiesDailyReservationList, getMyActivitiesDetailReservationList } from '@/apis/queryFunctions';
 import { QUERY_KEYS } from '@/apis/queryKeys';
 import { getDateStringKR, getScheduleDropdownOption, getStatusCountByScheduleId } from '@/utils';
 
@@ -51,8 +51,8 @@ const ModalContents = ({ gameId, activeDate, onClickCloseButton, onClickCardButt
   const currentDeviceType = useDeviceType();
 
   const { data: detailReservations } = useQuery({
-    queryKey: QUERY_KEYS.myActivities.getHourlyReservationList(gameId, scheduleId, selectedStatus),
-    queryFn: () => getMyActivitiesHourlyReservationList(gameId, scheduleId, selectedStatus),
+    queryKey: QUERY_KEYS.myActivities.getDetailReservationList(gameId, scheduleId, selectedStatus),
+    queryFn: () => getMyActivitiesDetailReservationList(gameId, scheduleId, selectedStatus),
   });
 
   const { totalCount, reservations } = detailReservations;

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -3,7 +3,7 @@ import { MouseEventHandler, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 
-import { getMyActivitiesDailyReservationList } from '@/apis/queryFunctions';
+import { getMyActivitiesDailyReservationList, getMyActivitiesHourlyReservationList } from '@/apis/queryFunctions';
 import { QUERY_KEYS } from '@/apis/queryKeys';
 import { getDateStringKR, getScheduleDropdownOption, getStatusCountByScheduleId } from '@/utils';
 
@@ -52,7 +52,7 @@ const ModalContents = ({ gameId, activeDate, onClickCloseButton, onClickCardButt
 
   const { data: detailReservations } = useQuery({
     queryKey: QUERY_KEYS.myActivities.getHourlyReservationList(gameId, scheduleId, selectedStatus),
-    queryFn: () => getMyActivitiesDailyReservationList(gameId, activeDate),
+    queryFn: () => getMyActivitiesHourlyReservationList(gameId, scheduleId, selectedStatus),
   });
 
   const { totalCount, reservations } = detailReservations;

--- a/src/components/calendar/ModalContents/index.tsx
+++ b/src/components/calendar/ModalContents/index.tsx
@@ -26,7 +26,7 @@ type ModalContentsProps = {
   dropdownOptions: { title: string; value: number | string }[];
   statusCountByScheduleId: { [id: number]: DailyReservationCount };
   onClickCloseButton: MouseEventHandler<HTMLButtonElement>;
-  onClickCardButton: (text: string) => void;
+  onClickCardButton: (scheduleId: number, reservationId: number, status: ReservationStatus) => void;
 };
 
 const ModalContents = ({
@@ -85,6 +85,8 @@ const ModalContents = ({
             {reservations.map(({ id, nickname, headCount, status }: ReservationDetail) => (
               <li key={`card-${id}`}>
                 <ModalCard
+                  scheduleId={scheduleId}
+                  reservationId={id}
                   nickName={nickname}
                   headCount={headCount}
                   status={status as ReservationStatus}

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -170,9 +170,9 @@ const Calendar = ({ gameId }: CalendarProps) => {
         warning
         openModal={multiState.confirmModal}
         onClose={() => toggleClick('confirmModal')}
-        state='STOP'
+        state='CONFIRM'
         title={`예약 신청을 ${MY_RESERVATIONS_STATUS[reservationStatus]}하시겠습니까?`}
-        desc={`한번 ${MY_RESERVATIONS_STATUS[reservationStatus]}한 예약은 되돌릴 수 없습니다.`}
+        desc={`한번 ${MY_RESERVATIONS_STATUS[reservationStatus]}한 예약은 되돌릴 수 없습니다`}
         renderButton={
           <>
             <ModalButton variant='warning' onClick={handleChangeReservationStatus}>

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -28,6 +28,7 @@ const cx = classNames.bind(styles);
 
 const MONTH_START = 1;
 const MONTH_END = 12;
+const BODY_OVERFLOW_HIDDEN = 'CommonModal_body-open__a3jYd';
 
 type CalendarProps = {
   gameId: number;
@@ -118,6 +119,12 @@ const Calendar = ({ gameId }: CalendarProps) => {
   useEffect(() => {
     if (currentDeviceType !== 'PC') setIsCalendar(false);
   }, [currentDeviceType]);
+
+  useEffect(() => {
+    if (!multiState.scheduleModal) {
+      document.body.classList.remove(BODY_OVERFLOW_HIDDEN);
+    }
+  }, [multiState.scheduleModal]);
 
   return (
     <>

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -3,9 +3,9 @@ import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 
-import { getMyActivitiesMonthlyReservationList } from '@/apis/queryFunctions';
+import { getMyActivitiesDailyReservationList, getMyActivitiesMonthlyReservationList } from '@/apis/queryFunctions';
 import { QUERY_KEYS } from '@/apis/queryKeys';
-import { getCurrentDate, getScheduleByDate } from '@/utils';
+import { getCurrentDate, getScheduleByDate, getScheduleDropdownOption, getStatusCountByScheduleId } from '@/utils';
 
 import CalendarBody from '@/components/calendar/CalendarBody';
 import CalendarHeader from '@/components/calendar/CalendarHeader';
@@ -45,6 +45,15 @@ const Calendar = ({ gameId }: CalendarProps) => {
     queryKey: QUERY_KEYS.myActivities.getMonthlyReservationList(gameId, yearString, monthString),
     queryFn: () => getMyActivitiesMonthlyReservationList(gameId, yearString, monthString),
   });
+
+  const { data: dailySchedules, isSuccess } = useQuery({
+    queryKey: QUERY_KEYS.myActivities.getDailyReservationList(gameId, activeDate),
+    queryFn: () => getMyActivitiesDailyReservationList(gameId, activeDate),
+    enabled: !!activeDate,
+  });
+
+  const dropdownOptions = getScheduleDropdownOption(dailySchedules);
+  const statusCountByScheduleId = getStatusCountByScheduleId(dailySchedules);
 
   const handleChangeMonth = (addNumber: number) => {
     const newMonth = currentMonth + addNumber;
@@ -96,20 +105,24 @@ const Calendar = ({ gameId }: CalendarProps) => {
           <ListBody schedules={monthlySchedule} onClick={handleScheduleClick} />
         )}
       </div>
-      <CommonModal
-        openModal={multiState.scheduleModal}
-        onClose={() => toggleClick('scheduleModal')}
-        title={'예약 정보'}
-        isResponsive
-        renderContent={
-          <ModalContents
-            gameId={gameId}
-            activeDate={activeDate}
-            onClickCloseButton={() => toggleClick('scheduleModal')}
-            onClickCardButton={handleConfirmClick}
-          />
-        }
-      />
+      {isSuccess && (
+        <CommonModal
+          openModal={multiState.scheduleModal}
+          onClose={() => toggleClick('scheduleModal')}
+          title={'예약 정보'}
+          isResponsive
+          renderContent={
+            <ModalContents
+              gameId={gameId}
+              activeDate={activeDate}
+              dropdownOptions={dropdownOptions}
+              statusCountByScheduleId={statusCountByScheduleId}
+              onClickCloseButton={() => toggleClick('scheduleModal')}
+              onClickCardButton={handleConfirmClick}
+            />
+          }
+        />
+      )}
       <ConfirmModal
         warning
         openModal={multiState.confirmModal}

--- a/src/components/commons/cards/RegisteredCard.tsx
+++ b/src/components/commons/cards/RegisteredCard.tsx
@@ -120,7 +120,7 @@ export const RegisteredCard = ({
         openModal={multiState.errorModal}
         onClose={() => toggleClick('errorModal')}
         state='ERROR'
-        title='신청 예약이 있는 체험은 삭제할 수 없습니다.'
+        title='신청 예약이 있는 체험은 삭제할 수 없습니다'
         renderButton={<ModalButton onClick={() => toggleClick('errorModal')}>닫기</ModalButton>}
       ></ConfirmModal>
     </>

--- a/src/components/commons/cards/RegisteredCard.tsx
+++ b/src/components/commons/cards/RegisteredCard.tsx
@@ -43,7 +43,7 @@ export const RegisteredCard = ({
   category,
   createdAt,
 }: RegisteredCardProps) => {
-  const { multiState, toggleClick } = useMultiState(['warningModal, errorModal']);
+  const { multiState, toggleClick } = useMultiState(['warningModal', 'errorModal']);
   const isOffline = postType === 'offline';
 
   const queryClient = useQueryClient();

--- a/src/components/commons/cards/RegisteredCard.tsx
+++ b/src/components/commons/cards/RegisteredCard.tsx
@@ -120,7 +120,7 @@ export const RegisteredCard = ({
         openModal={multiState.errorModal}
         onClose={() => toggleClick('errorModal')}
         state='ERROR'
-        title='게시물 삭제에 실패하였습니다.'
+        title='신청 예약이 있는 체험은 삭제할 수 없습니다.'
         renderButton={<ModalButton onClick={() => toggleClick('errorModal')}>닫기</ModalButton>}
       ></ConfirmModal>
     </>

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -39,7 +39,7 @@ const initialSortOption: SortOption<MyActivitiesResponse> = {
 };
 
 const MyPosts = () => {
-  const { data: initialDataList } = useQuery({
+  const { data: initialDataList = [] } = useQuery({
     queryKey: QUERY_KEYS.myActivities.getList,
     queryFn: getMyActivitiesList,
   });

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -39,7 +39,7 @@ const initialSortOption: SortOption<MyActivitiesResponse> = {
 };
 
 const MyPosts = () => {
-  const { data: initialDataList = [] } = useQuery({
+  const { data: initialDataList } = useQuery({
     queryKey: QUERY_KEYS.myActivities.getList,
     queryFn: getMyActivitiesList,
   });

--- a/src/components/mypage/MyPosts/index.tsx
+++ b/src/components/mypage/MyPosts/index.tsx
@@ -6,7 +6,12 @@ import classNames from 'classnames/bind';
 import { getMyActivitiesList } from '@/apis/queryFunctions';
 import { QUERY_KEYS } from '@/apis/queryKeys';
 import { GAME_FILTERS, GAME_NAME_EN_TO_KR, PAGE_PATHS, PRICE_TO_POST_TYPES, SORT_OPTIONS } from '@/constants';
-import { formatCategoryToGameNameEN, formatCategoryToGameNameKR, formatGameToLink } from '@/utils';
+import {
+  formatCategoryToGameNameEN,
+  formatCategoryToGameNameKR,
+  formatGameToLink,
+  splitTitleByDelimiter,
+} from '@/utils';
 import { getPostPageSize } from '@/utils/getPageSize';
 
 import { RegisteredCard } from '@/components/commons/cards';
@@ -81,6 +86,7 @@ const MyPosts = () => {
               const gameNameKR = GAME_NAME_EN_TO_KR[gameNameEN];
               const gameLink = formatGameToLink(gameNameEN);
               const postType = PRICE_TO_POST_TYPES[data.price];
+              const { title } = splitTitleByDelimiter(data.title);
 
               return (
                 <li key={data.id}>
@@ -89,7 +95,7 @@ const MyPosts = () => {
                     path={`/${gameLink}/${data.id}`}
                     editPath={`/${gameLink}/${PAGE_PATHS.create}/${data.id}`}
                     postType={postType}
-                    title={data.title}
+                    title={title}
                     address={data.address}
                     category={gameNameKR}
                     createdAt={data.createdAt}

--- a/src/components/mypage/ReservationStatus/index.tsx
+++ b/src/components/mypage/ReservationStatus/index.tsx
@@ -22,10 +22,12 @@ const ReservationStatus = () => {
     queryFn: getMyActivitiesList,
   });
 
-  const postDropdownOptions = myActivityDatas.map((data: MyActivitiesResponse) => ({
-    title: splitTitleByDelimiter(data.title).title,
-    value: data.id,
-  }));
+  const postDropdownOptions = myActivityDatas
+    .filter((data: MyActivitiesResponse) => data.price < 2)
+    .map((data: MyActivitiesResponse) => ({
+      title: splitTitleByDelimiter(data.title).title,
+      value: data.id,
+    }));
 
   const [gameId, setGameId] = useState(postDropdownOptions[0].value);
 

--- a/src/components/mypage/ReservationStatus/index.tsx
+++ b/src/components/mypage/ReservationStatus/index.tsx
@@ -1,17 +1,31 @@
 import { useState } from 'react';
 
+import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
+
+import { getMyActivitiesList } from '@/apis/queryFunctions';
+import { QUERY_KEYS } from '@/apis/queryKeys';
+import { splitTitleByDelimiter } from '@/utils';
 
 import Calendar from '@/components/calendar';
 import Dropdown from '@/components/commons/Dropdown';
-import MockActivityDatas from '@/constants/mockData/myActivitiesMockData.json';
+
+import { MyActivitiesResponse } from '@/types';
 
 import styles from './ReservationStatus.module.scss';
 
 const cx = classNames.bind(styles);
 
 const ReservationStatus = () => {
-  const postDropdownOptions = MockActivityDatas.map(({ id, title }) => ({ title, value: id }));
+  const { data: myActivityDatas } = useQuery({
+    queryKey: QUERY_KEYS.myActivities.getList,
+    queryFn: getMyActivitiesList,
+  });
+
+  const postDropdownOptions = myActivityDatas.map((data: MyActivitiesResponse) => ({
+    title: splitTitleByDelimiter(data.title).title,
+    value: data.id,
+  }));
 
   const [gameId, setGameId] = useState(postDropdownOptions[0].value);
 

--- a/src/types/myActivities.ts
+++ b/src/types/myActivities.ts
@@ -3,7 +3,7 @@ import { MyReservationsStatus } from '@/types';
 export type ReservationStatus = Exclude<MyReservationsStatus, 'canceled' | 'completed'>;
 
 export type EditReservationStatusBody = {
-  status: Extract<MyReservationsStatus, 'confirmed' | 'declined'>;
+  status: ReservationStatus;
 };
 
 export type MyActivitiesBody = {
@@ -75,4 +75,10 @@ export type Review = {
   content: string;
   createdAt: string;
   updatedAt: string;
+};
+
+export type changeStatusMutationParams = {
+  activityId: number;
+  reservationId: number;
+  status: EditReservationStatusBody;
 };

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,4 +1,4 @@
-import { MyReservationsStatus, MyReservationsStatusKR, ReservationResponse } from '@/types';
+import { MyReservationsStatusKR, ReservationResponse, ReservationStatus } from '@/types';
 
 export type AvailableSchedule = {
   date: string;
@@ -43,7 +43,7 @@ export type ReservationDetail = Omit<ReservationResponse, 'activity'> & {
 export type ReservationsByDate = Record<string, MonthlyReservationCount>;
 
 export type StatusTabOptions = {
-  id: MyReservationsStatus;
+  id: ReservationStatus;
   text: MyReservationsStatusKR;
   count: number;
 };


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #135 
- close #135 

## 유형

- [X] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 마이페이지의 예약 현황 페이지를 실제 API 와 연동

## 설명

### 📌 기능
- 내 게시글 중 온라인/오프라인 모집 게시글만 드롭다운에 표시
- 선택된 모집 게시글에 대한 월별 예약 현황 데이터를 받아와서 달력에 표시
- 달력을 클릭하면 해당 날짜에 대한 시간별 스케줄 정보를 모달에 표시
- 모달에 스케줄 ID 별 예약 현황 표시
- pending 상태인 예약 내역에 대한 승인/거절 기능 구현

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 🎥 모션 영상

https://github.com/sprint-team3/GGF/assets/43297823/063ca1a5-482d-4c60-aee7-6497bc97fb97

### 📸 디바이스별 스크린샷

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
