### PR TITLE
Hotfix: header api 요청 layout으로 변경

### DIFF
--- a/src/components/layout/Layout/index.tsx
+++ b/src/components/layout/Layout/index.tsx
@@ -1,9 +1,14 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 
 import classNames from 'classnames/bind';
 
+import { getCSRCookie } from '@/utils';
+
 import { Chatbot } from '@/components/commons/chatbot';
 import Header from '@/components/layout/header/Header';
+import useAlarmData from '@/hooks/useAlarmData';
+import useUserData from '@/hooks/useUserData';
+import useUserStore from '@/stores/useUserStore';
 
 import styles from './Layout.module.scss';
 
@@ -14,10 +19,20 @@ type LayoutProps = {
 };
 
 const Layout = ({ children }: LayoutProps) => {
+  const { accessToken } = getCSRCookie();
+  const { setUserData } = useUserStore();
+
+  const { userData } = useUserData(accessToken);
+  const { alarmData } = useAlarmData(accessToken);
+
+  useEffect(() => {
+    setUserData(userData);
+  }, [userData]);
+
   return (
     <>
       <div className={cx('header')}>
-        <Header />
+        <Header userData={userData} alarmData={alarmData} accessToken={accessToken} />
       </div>
       <div className={cx('content')}>
         {children}

--- a/src/components/layout/header/Header/index.tsx
+++ b/src/components/layout/header/Header/index.tsx
@@ -5,8 +5,7 @@ import { useEffect, useState } from 'react';
 
 import classNames from 'classnames/bind';
 
-import { SVGS } from '@/constants';
-import { getCSRCookie } from '@/utils';
+import { PAGE_PATHS, SVGS } from '@/constants';
 
 import Alarm from '@/components/layout/header/Alarm';
 import AlarmList from '@/components/layout/header/AlarmList';
@@ -15,20 +14,26 @@ import DrawerMenu from '@/components/layout/header/DrawerMenu';
 import HeaderProfile from '@/components/layout/header/HeaderProfile';
 import Menu from '@/components/layout/header/Menu';
 import UserMenu from '@/components/layout/header/UserMenu';
-import useAlarmData from '@/hooks/useAlarmData';
 import { useDeviceType } from '@/hooks/useDeviceType';
 import useTogglePopup from '@/hooks/useTogglePopup';
-import useUserData from '@/hooks/useUserData';
-import useUserStore from '@/stores/useUserStore';
+
+import { MyNotifications, UsersResponse } from '@/types';
 
 import styles from './Header.module.scss';
 
 const cx = classNames.bind(styles);
 const { url, alt } = SVGS.drawerMenu;
 
-const Header = () => {
+type HeaderProps = {
+  userData: UsersResponse;
+  alarmData: MyNotifications;
+  accessToken: string;
+};
+
+const Header = ({ userData, alarmData, accessToken }: HeaderProps) => {
   const currentDeviceType = useDeviceType();
   const isMobileHidden = currentDeviceType !== 'Mobile';
+
   const [isVisible, setIsVisible] = useState<boolean>();
   const [isAlarmExisted, setIsAlarmExisted] = useState(false);
 
@@ -56,10 +61,6 @@ const Header = () => {
     togglePopup: handleHeaderProfileActivation,
   } = useTogglePopup();
 
-  const { accessToken } = getCSRCookie();
-
-  const { alarmData } = useAlarmData(accessToken);
-
   const totalCount = alarmData?.totalCount;
   const notifications = alarmData?.notifications;
 
@@ -67,17 +68,9 @@ const Header = () => {
     setIsAlarmExisted(totalCount > 0);
   }, [totalCount]);
 
-  const { userData, isSuccess: isUserDataSuccess } = useUserData(accessToken);
-
-  const { setUserData } = useUserStore();
-
   const email = userData?.email;
   const nickname = userData?.nickname;
-  const profileImageUrl = userData?.profileImageUrl;
-
-  useEffect(() => {
-    setUserData(userData);
-  }, [userData]);
+  const profileImageUrl = userData?.profileImageUrl || '';
 
   return (
     <>
@@ -86,7 +79,7 @@ const Header = () => {
           <button className={cx('header-menu-button', 'sm-only')} onClick={handleToggleDrawerMenu}>
             <Image src={url} alt={alt} width={24} height={24}></Image>
           </button>
-          <Link className={cx('header-logo')} href={'/landing'}>
+          <Link className={cx('header-logo')} href={PAGE_PATHS.landing}>
             GGF
           </Link>
           <div className={cx('header-container-outer')}>
@@ -94,7 +87,7 @@ const Header = () => {
               <Menu />
             </div>
             <div className={cx('header-container-inner')}>
-              {accessToken && isUserDataSuccess ? (
+              {accessToken && alarmData && userData ? (
                 <>
                   <Alarm
                     isActivated={isAlarmActivated}


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 기존에 header에서 userData와 alarmData를 요청하던 것을 layout에서 하는 것으로 수정했습니다.
- 이에 따라 header의 props에 userData, alarmData, accessToken이 추가되었습니다.