### PR TITLE
Hotfix: account 비밀번호 변경시 데이터 키값 수정, 유저 정보 수정시 userData refetch

### DIFF
--- a/src/apis/users/schema.ts
+++ b/src/apis/users/schema.ts
@@ -22,7 +22,7 @@ export const PasswordSchema = z
       .regex(REGEX.password, ERROR_MESSAGE.password.regex),
     [passwordConfirm]: z.string(),
   })
-  .refine((data) => data.password === data.passwordConfirm, {
+  .refine((data) => data[password] === data[passwordConfirm], {
     path: [passwordConfirm],
     message: ERROR_MESSAGE.password.refine,
   });

--- a/src/components/AccountForm/index.tsx
+++ b/src/components/AccountForm/index.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 import { FormProvider, useForm } from 'react-hook-form';
 
@@ -124,6 +124,7 @@ const AccountForm = () => {
   });
 
   const { setUserData } = useUserStore();
+  const queryClient = useQueryClient();
 
   const { mutate: profileMutation } = useMutation({
     mutationFn: Users.edit,
@@ -131,6 +132,7 @@ const AccountForm = () => {
     onSuccess(data) {
       const { profileImageUrl } = data.data;
       setNewImageUrl(profileImageUrl);
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.users.get] });
       setUserData(data.data);
       toggleClick('saveAlertModal');
     },

--- a/src/constants/inputNames.ts
+++ b/src/constants/inputNames.ts
@@ -1,7 +1,7 @@
 export const INPUT_NAMES = {
   profileImageUrl: 'profileImageUrl',
   nickname: 'nickname',
-  password: 'password',
+  password: 'newPassword',
   passwordConfirm: 'passwordConfirm',
   image: 'image',
 };


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- account 페이지에서 비밀번호 변경시 데이터의 키값이 다른 버그 발견하여 수정하였습니다.
- 유저 정보 수정 성공시 userData refetch 할 수 있도록 invalidateQueries 사용했습니다.
- account 페이지에서 정보 수정하면 userData참조하고 있는 header의 프로필 사진과 이미지도 바로 변경됩니다.