### PR TITLE
Hotfix: auth 로직 리팩토링

### DIFF
--- a/src/components/layout/Layout/index.tsx
+++ b/src/components/layout/Layout/index.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useEffect } from 'react';
 
 import classNames from 'classnames/bind';
 
-import { getCSRCookie } from '@/utils';
+import { getCSRLoggedIn } from '@/utils';
 
 import { Chatbot } from '@/components/commons/chatbot';
 import Header from '@/components/layout/header/Header';
@@ -19,11 +19,11 @@ type LayoutProps = {
 };
 
 const Layout = ({ children }: LayoutProps) => {
-  const { accessToken } = getCSRCookie();
+  const isLoggedIn = getCSRLoggedIn();
   const { setUserData } = useUserStore();
 
-  const { userData } = useUserData(accessToken);
-  const { alarmData } = useAlarmData(accessToken);
+  const { userData } = useUserData();
+  const { alarmData } = useAlarmData();
 
   useEffect(() => {
     setUserData(userData);
@@ -32,7 +32,7 @@ const Layout = ({ children }: LayoutProps) => {
   return (
     <>
       <div className={cx('header')}>
-        <Header userData={userData} alarmData={alarmData} accessToken={accessToken} />
+        <Header userData={userData} alarmData={alarmData} isLoggedIn={isLoggedIn} />
       </div>
       <div className={cx('content')}>
         {children}

--- a/src/components/layout/header/Header/index.tsx
+++ b/src/components/layout/header/Header/index.tsx
@@ -27,10 +27,10 @@ const { url, alt } = SVGS.drawerMenu;
 type HeaderProps = {
   userData: UsersResponse;
   alarmData: MyNotifications;
-  accessToken: string;
+  isLoggedIn: boolean;
 };
 
-const Header = ({ userData, alarmData, accessToken }: HeaderProps) => {
+const Header = ({ userData, alarmData, isLoggedIn }: HeaderProps) => {
   const currentDeviceType = useDeviceType();
   const isMobileHidden = currentDeviceType !== 'Mobile';
 
@@ -87,7 +87,7 @@ const Header = ({ userData, alarmData, accessToken }: HeaderProps) => {
               <Menu />
             </div>
             <div className={cx('header-container-inner')}>
-              {accessToken && alarmData && userData ? (
+              {isLoggedIn && alarmData && userData ? (
                 <>
                   <Alarm
                     isActivated={isAlarmActivated}

--- a/src/constants/initialData.ts
+++ b/src/constants/initialData.ts
@@ -6,3 +6,5 @@ export const INITIAL_DATA = {
     },
   },
 };
+
+export const USER_INITIAL_DATA = { id: 0, email: '', nickname: '', profileImageUrl: '', createdAt: '', updatedAt: '' };

--- a/src/hooks/useAlarmData.ts
+++ b/src/hooks/useAlarmData.ts
@@ -2,8 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getMyNotifications } from '@/apis/queryFunctions';
 import { QUERY_KEYS } from '@/apis/queryKeys';
+import { getCSRCookie } from '@/utils';
 
-const useAlarmData = (accessToken: string) => {
+const useAlarmData = () => {
+  const { accessToken } = getCSRCookie();
   const {
     data: alarmData,
     isSuccess,

--- a/src/hooks/useUserData.ts
+++ b/src/hooks/useUserData.ts
@@ -2,8 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getUser } from '@/apis/queryFunctions';
 import { QUERY_KEYS } from '@/apis/queryKeys';
+import { getCSRCookie } from '@/utils';
 
-const useUserData = (accessToken: string) => {
+const useUserData = () => {
+  const { accessToken } = getCSRCookie();
   const {
     data: userData,
     isSuccess,

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,16 +1,17 @@
 import { GetServerSidePropsContext } from 'next';
 
-import { getAuthCookie } from '@/utils';
+import { PAGE_PATHS } from '@/constants';
+import { getLoggedIn, renewAccess } from '@/utils';
 
 import SigninForm from '@/components/auth/SigninForm';
 
-export function getServerSideProps(context: GetServerSidePropsContext) {
-  const { accessToken } = getAuthCookie(context);
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  await renewAccess(context);
 
-  if (accessToken) {
+  if (getLoggedIn(context)) {
     return {
       redirect: {
-        destination: `/league-of-legends`,
+        destination: PAGE_PATHS.mainList,
         permanent: false,
       },
     };

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,16 +1,17 @@
 import { GetServerSidePropsContext } from 'next';
 
-import { getAuthCookie } from '@/utils';
+import { PAGE_PATHS } from '@/constants';
+import { getLoggedIn, renewAccess } from '@/utils';
 
 import SignupForm from '@/components/auth/SignupForm';
 
-export function getServerSideProps(context: GetServerSidePropsContext) {
-  const { accessToken } = getAuthCookie(context);
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  await renewAccess(context);
 
-  if (accessToken) {
+  if (getLoggedIn(context)) {
     return {
       redirect: {
-        destination: `/league-of-legends`,
+        destination: PAGE_PATHS.mainList,
         permanent: false,
       },
     };

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,14 +1,16 @@
 import { create } from 'zustand';
 
+import { USER_INITIAL_DATA } from '@/constants';
+
 import { UsersResponse } from '@/types';
 
 type UserStoreState = {
-  userData: UsersResponse | null;
+  userData: UsersResponse;
   setUserData: (newData: UsersResponse) => void;
 };
 
 const useUserStore = create<UserStoreState>((set) => ({
-  userData: null,
+  userData: USER_INITIAL_DATA,
   setUserData: (newData: UsersResponse) => set({ userData: newData }),
 }));
 

--- a/src/utils/cookieUtils.ts
+++ b/src/utils/cookieUtils.ts
@@ -36,3 +36,10 @@ export const getCSRCookie = () => {
 export const getLoggedIn = (context: GetServerSidePropsContext) => {
   return !!getAuthCookie(context).accessToken;
 };
+
+export const getCSRLoggedIn = () => {
+  const cookies = parseCookies();
+  const accessToken = cookies?.accessToken;
+  if (!accessToken) return false;
+  return true;
+};

--- a/src/utils/cookieUtils.ts
+++ b/src/utils/cookieUtils.ts
@@ -32,3 +32,7 @@ export const getCSRCookie = () => {
   const refreshToken = cookies?.refreshToken;
   return { accessToken, refreshToken };
 };
+
+export const getLoggedIn = (context: GetServerSidePropsContext) => {
+  return !!getAuthCookie(context).accessToken;
+};

--- a/src/utils/signout.ts
+++ b/src/utils/signout.ts
@@ -1,9 +1,11 @@
 import { destroyCookie } from 'nookies';
 
+import { USER_INITIAL_DATA } from '@/constants';
+
 import useUserStore from '@/stores/useUserStore';
 
 export const signout = () => {
   destroyCookie(null, 'accessToken');
   destroyCookie(null, 'refreshToken');
-  useUserStore.setState({ userData: null });
+  useUserStore.setState({ userData: USER_INITIAL_DATA });
 };


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [x] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 

## 설명

### 📌 기능
1. SSR에서 비로그인 유저 토큰 갱신하여 쿠키에 저장하는 함수 구현했습니다.
2. SSR에서 로그인상태 반환해주는 함수  구현했습니다.
3. CSR에서 로그인상태 반환해주는 함수  구현했습니다.
4. 로그인 상태로 로그인 회원가입 페이지 접속시 리다이렉트 및 액세스 토큰 갱신 적용했습니다.
5. useAlarmData, useUserData 훅에서 accessToken을 파람으로 받지 않도록 수정했습니다.
6. useUserStore의 userData 타입에서 null을 삭제하고, 초기값을 객체로 만들어 넣었습니다.


