### PR TITLE
Hotfix: 랜딩페이지에서 Menu 게임 카테고리 이름 보이지 않는 버그 해결

### DIFF
--- a/src/components/layout/header/Menu/index.tsx
+++ b/src/components/layout/header/Menu/index.tsx
@@ -13,7 +13,6 @@ const cx = classNames.bind(styles);
 const Menu = () => {
   const router = useRouter();
   const { game: gameName } = router.query;
-  if (!gameName) return;
 
   const isGameActivated = (index: number) => {
     return (


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- Menu의 gameName이 없을 때 early return문을 삭제하여 버그해결했습니다.
