### PR TITLE
Hotfix: 게시글 목록 상대경로 수정 및 title 데이터 매핑

### DIFF
--- a/src/components/listPage/PostList/index.tsx
+++ b/src/components/listPage/PostList/index.tsx
@@ -11,9 +11,8 @@ import {
   PRICE_TO_POST_TYPES,
   SORT_OPTIONS,
 } from '@/constants';
+import { splitTitleByDelimiter } from '@/utils';
 import { getPostPageSize } from '@/utils/getPageSize';
-
-import EmptyCard from '../../layout/empty/EmptyCard';
 
 import { BaseButton } from '@/components/commons/buttons/BaseButton';
 import { CommonCard } from '@/components/commons/cards/CommonCard';
@@ -21,6 +20,7 @@ import Dropdown from '@/components/commons/Dropdown';
 import { SearchBar } from '@/components/commons/inputs/SearchBar';
 import Pagination from '@/components/commons/Pagination';
 import Tab from '@/components/commons/Tab';
+import EmptyCard from '@/components/layout/empty/EmptyCard';
 import { useDeviceType } from '@/hooks/useDeviceType';
 import useProcessedDataList from '@/hooks/useProcessedDataList';
 
@@ -105,19 +105,23 @@ const PostList = ({ isLoggedIn, activitiesData: initialDataList }: PostListProps
         </div>
         {totalCount !== 0 ? (
           <ul className={cx('post-list-container-card-list')}>
-            {pagedDataList.map((data) => (
-              <li className={cx('card')} key={data.id}>
-                <CommonCard
-                  path={`/${game}/${data.id}`}
-                  postType={PRICE_TO_POST_TYPES[data.price]}
-                  title={data.title}
-                  address={data.address}
-                  rating={data.rating}
-                  reviewCount={data.reviewCount}
-                  createdAt={data.createdAt}
-                />
-              </li>
-            ))}
+            {pagedDataList.map((data) => {
+              const { title } = splitTitleByDelimiter(data.title);
+
+              return (
+                <li className={cx('card')} key={data.id}>
+                  <CommonCard
+                    path={`/${game}/${data.id}`}
+                    postType={PRICE_TO_POST_TYPES[data.price]}
+                    title={title}
+                    address={data.address}
+                    rating={data.rating}
+                    reviewCount={data.reviewCount}
+                    createdAt={data.createdAt}
+                  />
+                </li>
+              );
+            })}
           </ul>
         ) : (
           <EmptyCard text='No Post' />


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 게시글 목록 상대경로를 절대경로로 수정했습니다.
- title 데이터를 splitTitleByDelimiter 유틸함수를 통해 매핑하여 card의 prop으로 내려줍니다.

