### PR TITLE
Hotfix: 에코 이미지 변경 및 에코 위치 가운데로 오도록 수정

### DIFF
--- a/src/components/landing/Echo/Echo.module.scss
+++ b/src/components/landing/Echo/Echo.module.scss
@@ -10,37 +10,27 @@
 }
 
 .echo {
-  @include responsive(T) {
-    right: 60%;
-    transform: translateX(60%) !important;
-  }
+  @include pos-center-x;
 
-  position: absolute;
-  right: 0;
-
-  aspect-ratio: 1.69 / 1;
-  height: 100%;
-
+  width: 107%;
+  height: 107%;
   background: url('/pngs/landing-echo.png') no-repeat center/cover;
-
   animation: show-echo 1s ease-in-out forwards;
 }
 
 .echo-shadow {
-  @include responsive(T) {
-    right: 45%;
-    transform: translateX(45%) !important;
-  }
-
   position: absolute;
-  right: 10%;
+  left: 40%;
+  transform: translateX(-50%);
 
-  aspect-ratio: 1.69 / 1;
-  height: 110%;
+  width: 107%;
+  height: 107%;
 
+  opacity: 0;
   background: url('/pngs/landing-echo-shadow.png') no-repeat center/cover;
 
-  animation: show-echo-shadow 1s ease-in-out forwards;
+  animation: show-echo 1s ease-in-out forwards;
+  animation-delay: 0.5s;
 }
 
 .side-scroll {
@@ -234,23 +224,6 @@
 
 @keyframes show-echo {
   0% {
-    bottom: -10%;
-    opacity: 0;
-  }
-
-  100% {
-    bottom: -5%;
-    opacity: 1;
-  }
-}
-
-@keyframes show-echo-shadow {
-  0% {
-    bottom: -10%;
-    opacity: 0;
-  }
-
-  50% {
     bottom: -10%;
     opacity: 0;
   }

--- a/src/hooks/useMouseMoveEffect.ts
+++ b/src/hooks/useMouseMoveEffect.ts
@@ -42,8 +42,8 @@ const useMouseMoveEffect = (moveScale: number) => {
 
         mainText.style.transform = `translate(${offsetX * moveScale}px, ${offsetY * moveScale}px)`;
         subText.style.transform = `translate(${offsetX * moveScale}px, ${offsetY * moveScale}px)`;
-        echo.style.transform = `translate(${-offsetX * moveScale}px, ${-offsetY * moveScale}px)`;
-        echoShadow.style.transform = `translate(${offsetX * 1}px, ${offsetY * 1}px)`;
+        echo.style.transform = `translate(calc(-50% + ${-offsetX * moveScale}px), ${-offsetY * moveScale}px)`;
+        echoShadow.style.transform = `translate(calc(-50% + ${offsetX * 1}px), ${offsetY * 1}px)`;
       });
     };
 


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [X] UI 구현
- [ ] 리팩토링
- [X] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 에코 이미지 변경 및 에코 위치 가운데로 오도록 수정

## 설명

### 📌 UI
- 에코 이미지를 1920 기준 이미지로 변경했습니다
- 기존에 에코를 `right: 0` 으로 배치하던 부분을 `pos-center-x` 로 수정했습니다
- `!important` 를 제거하고 마우스 이동 hook에서 `tanslate`에 -50%를 더해주도록 해서 에코 탈출을 막았습니다