### PR TITLE
Hotfix: 랜딩 페이지-클랜 모집/슬라이더 이동 가능할 경우에만 arrow 버튼 나타나게 수정

### DIFF
--- a/src/components/landing/ClanRecruitment/ClanRecruitment.tsx
+++ b/src/components/landing/ClanRecruitment/ClanRecruitment.tsx
@@ -14,11 +14,12 @@ import styles from './ClanRecruitment.module.scss';
 
 const cx = classNames.bind(styles);
 
-const SCROLL_SLIDER_WIDTH = 1224;
-const MAX_DISPLAYED_CLAN_CARDS = 3;
 const POST_CATEGORY_CLAN = 2;
+const MAX_DISPLAYED_CLAN_CARDS = 3;
+const SCROLL_SLIDER_WIDTH = 1224;
 
 const ClanRecruitment = () => {
+  const sliderRef = useRef<HTMLDivElement>(null);
   const { data: lol } = useQuery({ queryKey: ['activities', '스포츠'], queryFn: getActivities });
   const { data: battlegrounds } = useQuery({ queryKey: ['activities', '투어'], queryFn: getActivities });
   const { data: overwatch } = useQuery({ queryKey: ['activities', '관광'], queryFn: getActivities });
@@ -41,21 +42,22 @@ const ClanRecruitment = () => {
     }
   }
 
-  const sliderRef = useRef<HTMLDivElement>(null);
-
+  const postClanCount = filterSliderClanList.length;
   const [currentSliderIndex, setCurrentSliderIndex] = useState(0);
+  const isNextSliderAvailable = currentSliderIndex + MAX_DISPLAYED_CLAN_CARDS <= postClanCount - 1;
+  const isPrevSliderAvailable = currentSliderIndex >= MAX_DISPLAYED_CLAN_CARDS;
 
   const handleNextClick = () => {
-    if (sliderRef.current && currentSliderIndex < MAX_DISPLAYED_CLAN_CARDS) {
+    if (sliderRef.current && isNextSliderAvailable) {
       sliderRef.current.scrollLeft += SCROLL_SLIDER_WIDTH;
-      setCurrentSliderIndex((prev) => prev + 1);
+      setCurrentSliderIndex((prev) => prev + MAX_DISPLAYED_CLAN_CARDS);
     }
   };
 
   const handlePrevClick = () => {
-    if (sliderRef.current && currentSliderIndex > 0) {
+    if (sliderRef.current && isPrevSliderAvailable) {
       sliderRef.current.scrollLeft -= SCROLL_SLIDER_WIDTH;
-      setCurrentSliderIndex((prev) => prev - 1);
+      setCurrentSliderIndex((prev) => prev - MAX_DISPLAYED_CLAN_CARDS);
     }
   };
 
@@ -74,9 +76,11 @@ const ClanRecruitment = () => {
         </header>
 
         <div className={cx('clan-slider')}>
-          <div className={cx('clan-slider-btn-prev')}>
-            <SliderButton type='left' onClick={handlePrevClick} />
-          </div>
+          {isPrevSliderAvailable && (
+            <div className={cx('clan-slider-btn-prev')}>
+              <SliderButton type='left' onClick={handlePrevClick} />
+            </div>
+          )}
 
           <div className={cx('slider-banner')} ref={sliderRef}>
             <ul className={cx('slider-banner-list')}>
@@ -93,9 +97,11 @@ const ClanRecruitment = () => {
             </ul>
           </div>
 
-          <div className={cx('clan-slider-btn-next')}>
-            <SliderButton type='right' onClick={handleNextClick} />
-          </div>
+          {isNextSliderAvailable && (
+            <div className={cx('clan-slider-btn-next')}>
+              <SliderButton type='right' onClick={handleNextClick} />
+            </div>
+          )}
         </div>
       </div>
     </section>


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 고정된 인덱스 값을 기준으로 데이터가 4개 미만일 때도 슬라이더가 이동되는 오류 해결

## 설명

### 📌 기능
- 슬라이더를 이동할 수 있는 경우에만 화살표 버튼이 나타나고, 슬라이더가 이동됩니다.
- 이동이 불가능한 경우에는 버튼이 사라지며 슬라이더도 움직이지 않습니다.

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 🎥 모션 영상


https://github.com/sprint-team3/GGF/assets/77719310/6a5cb16b-e745-42d7-a4fd-2e6a2b3b75f7

