### PR TITLE
Feat[#300]: Div 태그의 background-image 를 Image 태그로 변경

### DIFF
--- a/src/components/auth/SigninForm/SigninForm.module.scss
+++ b/src/components/auth/SigninForm/SigninForm.module.scss
@@ -4,9 +4,7 @@
   height: 100%;
 
   &-image {
-    z-index: $glitch-1-level;
-    object-fit: cover;
-    object-position: center;
+    @include image-background;
   }
 
   .signin {

--- a/src/components/auth/SigninForm/SigninForm.module.scss
+++ b/src/components/auth/SigninForm/SigninForm.module.scss
@@ -1,7 +1,13 @@
 .container {
+  position: relative;
   width: 100%;
   height: 100%;
-  background: url('/images/auth-background.webp') no-repeat center/cover;
+
+  &-image {
+    z-index: $glitch-1-level;
+    object-fit: cover;
+    object-position: center;
+  }
 
   .signin {
     @include responsive(M) {

--- a/src/components/auth/SigninForm/index.tsx
+++ b/src/components/auth/SigninForm/index.tsx
@@ -71,7 +71,7 @@ const SigninForm = () => {
 
   return (
     <section className={cx('container')}>
-      <Image src={WEBPS.auth.url} alt={WEBPS.auth.alt} fill priority className={cx('container-image')} />
+      <Image src={WEBPS.auth.url} alt={WEBPS.auth.alt} fill priority sizes='100%' className={cx('container-image')} />
       <div className={cx('signin')}>
         <header className={cx('signin-header')}>
           <span className={cx('signin-header-main-title')}>

--- a/src/components/auth/SigninForm/index.tsx
+++ b/src/components/auth/SigninForm/index.tsx
@@ -71,7 +71,15 @@ const SigninForm = () => {
 
   return (
     <section className={cx('container')}>
-      <Image src={WEBPS.auth.url} alt={WEBPS.auth.alt} fill priority sizes='100%' className={cx('container-image')} />
+      <Image
+        src={WEBPS.auth.url}
+        alt={WEBPS.auth.alt}
+        fill
+        priority
+        sizes='100%'
+        className={cx('container-image')}
+        unoptimized
+      />
       <div className={cx('signin')}>
         <header className={cx('signin-header')}>
           <span className={cx('signin-header-main-title')}>

--- a/src/components/auth/SigninForm/index.tsx
+++ b/src/components/auth/SigninForm/index.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -8,7 +9,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { Auth } from '@/apis/auth';
-import { API_ERROR_MESSAGE, ERROR_MESSAGE, PAGE_PATHS, REGEX } from '@/constants';
+import { API_ERROR_MESSAGE, ERROR_MESSAGE, PAGE_PATHS, REGEX, WEBPS } from '@/constants';
 import { redirectToPage, setAuthCookie } from '@/utils';
 
 import AuthInputField from '@/components/auth/AuthInputField';
@@ -70,6 +71,7 @@ const SigninForm = () => {
 
   return (
     <section className={cx('container')}>
+      <Image src={WEBPS.auth.url} alt={WEBPS.auth.alt} fill priority className={cx('container-image')} />
       <div className={cx('signin')}>
         <header className={cx('signin-header')}>
           <span className={cx('signin-header-main-title')}>

--- a/src/components/auth/SignupForm/SignupForm.module.scss
+++ b/src/components/auth/SignupForm/SignupForm.module.scss
@@ -4,9 +4,7 @@
   height: 100%;
 
   &-image {
-    z-index: $glitch-1-level;
-    object-fit: cover;
-    object-position: center;
+    @include image-background;
   }
 
   .signup {

--- a/src/components/auth/SignupForm/SignupForm.module.scss
+++ b/src/components/auth/SignupForm/SignupForm.module.scss
@@ -1,7 +1,13 @@
 .container {
+  position: relative;
   width: 100%;
   height: 100%;
-  background: url('/images/auth-background.webp') no-repeat center/cover;
+
+  &-image {
+    z-index: $glitch-1-level;
+    object-fit: cover;
+    object-position: center;
+  }
 
   .signup {
     @include responsive(M) {

--- a/src/components/auth/SignupForm/index.tsx
+++ b/src/components/auth/SignupForm/index.tsx
@@ -80,7 +80,15 @@ const SignupForm = () => {
   return (
     <>
       <section className={cx('container')}>
-        <Image src={WEBPS.auth.url} alt={WEBPS.auth.alt} fill priority sizes='100%' className={cx('container-image')} />
+        <Image
+          src={WEBPS.auth.url}
+          alt={WEBPS.auth.alt}
+          fill
+          priority
+          sizes='100%'
+          className={cx('container-image')}
+          unoptimized
+        />
         <div className={cx('signup')}>
           <header className={cx('signup-header')}>
             <span className={cx('signup-header-main-title')}>

--- a/src/components/auth/SignupForm/index.tsx
+++ b/src/components/auth/SignupForm/index.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -8,7 +9,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { Users } from '@/apis/users';
-import { API_ERROR_MESSAGE, ERROR_MESSAGE, PAGE_PATHS, REGEX } from '@/constants';
+import { API_ERROR_MESSAGE, ERROR_MESSAGE, PAGE_PATHS, REGEX, WEBPS } from '@/constants';
 import { redirectToPage } from '@/utils';
 
 import AuthInputField from '@/components/auth/AuthInputField';
@@ -79,6 +80,7 @@ const SignupForm = () => {
   return (
     <>
       <section className={cx('container')}>
+        <Image src={WEBPS.auth.url} alt={WEBPS.auth.alt} fill priority className={cx('container-image')} />
         <div className={cx('signup')}>
           <header className={cx('signup-header')}>
             <span className={cx('signup-header-main-title')}>

--- a/src/components/auth/SignupForm/index.tsx
+++ b/src/components/auth/SignupForm/index.tsx
@@ -80,7 +80,7 @@ const SignupForm = () => {
   return (
     <>
       <section className={cx('container')}>
-        <Image src={WEBPS.auth.url} alt={WEBPS.auth.alt} fill priority className={cx('container-image')} />
+        <Image src={WEBPS.auth.url} alt={WEBPS.auth.alt} fill priority sizes='100%' className={cx('container-image')} />
         <div className={cx('signup')}>
           <header className={cx('signup-header')}>
             <span className={cx('signup-header-main-title')}>

--- a/src/components/landing/Echo/Echo.module.scss
+++ b/src/components/landing/Echo/Echo.module.scss
@@ -1,12 +1,19 @@
+%image-fit-center {
+  object-fit: cover;
+  object-position: center;
+}
+
 .container {
   position: relative;
-
   overflow: hidden;
-
   width: 100%;
   height: 100vh;
 
-  background: url('/images/landing-echo-background.webp') no-repeat center/cover;
+  &-image {
+    @extend %image-fit-center;
+
+    z-index: $glitch-1-level;
+  }
 }
 
 .echo {
@@ -14,23 +21,29 @@
 
   width: 107%;
   height: 107%;
-  background: url('/images/landing-echo.webp') no-repeat center/cover;
   animation: show-echo 1s ease-in-out forwards;
-}
 
-.echo-shadow {
-  position: absolute;
-  left: 40%;
-  transform: translateX(-50%);
+  &-image {
+    @extend %image-fit-center;
+  }
 
-  width: 107%;
-  height: 107%;
+  &-shadow {
+    position: absolute;
+    left: 40%;
+    transform: translateX(-50%);
 
-  opacity: 0;
-  background: url('/images/landing-echo-shadow.webp') no-repeat center/cover;
+    width: 107%;
+    height: 107%;
 
-  animation: show-echo 1s ease-in-out forwards;
-  animation-delay: 0.5s;
+    opacity: 0;
+
+    animation: show-echo 1s ease-in-out forwards;
+    animation-delay: 0.5s;
+
+    &-image {
+      @extend %image-fit-center;
+    }
+  }
 }
 
 .side-scroll {

--- a/src/components/landing/Echo/Echo.module.scss
+++ b/src/components/landing/Echo/Echo.module.scss
@@ -1,8 +1,3 @@
-%image-fit-center {
-  object-fit: cover;
-  object-position: center;
-}
-
 .container {
   position: relative;
   overflow: hidden;
@@ -10,9 +5,7 @@
   height: 100vh;
 
   &-image {
-    @extend %image-fit-center;
-
-    z-index: $glitch-1-level;
+    @include image-background;
   }
 }
 
@@ -24,7 +17,7 @@
   animation: show-echo 1s ease-in-out forwards;
 
   &-image {
-    @extend %image-fit-center;
+    @include image-center-cover;
   }
 
   &-shadow {
@@ -41,7 +34,7 @@
     animation-delay: 0.5s;
 
     &-image {
-      @extend %image-fit-center;
+      @include image-center-cover;
     }
   }
 }

--- a/src/components/landing/Echo/index.tsx
+++ b/src/components/landing/Echo/index.tsx
@@ -21,6 +21,7 @@ const Echo = () => {
         alt={WEBPS.landing.echoBackground.alt}
         fill
         priority
+        sizes='100%'
         className={cx('container-image')}
       />
       <div ref={echoShadowRef} className={cx('echo-shadow')}>
@@ -29,11 +30,19 @@ const Echo = () => {
           alt={WEBPS.landing.echoShadow.alt}
           fill
           priority
+          sizes='100%'
           className={cx('echo-shadow-image')}
         />
       </div>
       <div ref={echoRef} className={cx('echo')}>
-        <Image src={WEBPS.landing.echo.url} alt={WEBPS.landing.echo.alt} fill priority className={cx('echo-image')} />
+        <Image
+          src={WEBPS.landing.echo.url}
+          alt={WEBPS.landing.echo.alt}
+          fill
+          priority
+          sizes='100%'
+          className={cx('echo-image')}
+        />
       </div>
       <div className={cx('side-scroll', 'left')}>
         <ul className={cx('scroll-content', 'left')}>

--- a/src/components/landing/Echo/index.tsx
+++ b/src/components/landing/Echo/index.tsx
@@ -23,6 +23,7 @@ const Echo = () => {
         priority
         sizes='100%'
         className={cx('container-image')}
+        unoptimized
       />
       <div ref={echoShadowRef} className={cx('echo-shadow')}>
         <Image
@@ -32,6 +33,7 @@ const Echo = () => {
           priority
           sizes='100%'
           className={cx('echo-shadow-image')}
+          unoptimized
         />
       </div>
       <div ref={echoRef} className={cx('echo')}>
@@ -42,6 +44,7 @@ const Echo = () => {
           priority
           sizes='100%'
           className={cx('echo-image')}
+          unoptimized
         />
       </div>
       <div className={cx('side-scroll', 'left')}>

--- a/src/components/landing/Echo/index.tsx
+++ b/src/components/landing/Echo/index.tsx
@@ -1,8 +1,9 @@
+import Image from 'next/image';
 import Link from 'next/link';
 
 import classNames from 'classnames/bind';
 
-import { GAME_NAME_LIST_EN, PAGE_PATHS } from '@/constants';
+import { GAME_NAME_LIST_EN, PAGE_PATHS, WEBPS } from '@/constants';
 
 import useMouseMoveEffect from '@/hooks/useMouseMoveEffect';
 
@@ -15,8 +16,25 @@ const Echo = () => {
 
   return (
     <section ref={containerRef} className={cx('container')}>
-      <div ref={echoShadowRef} className={cx('echo-shadow')}></div>
-      <div ref={echoRef} className={cx('echo')}></div>
+      <Image
+        src={WEBPS.landing.echoBackground.url}
+        alt={WEBPS.landing.echoBackground.alt}
+        fill
+        priority
+        className={cx('container-image')}
+      />
+      <div ref={echoShadowRef} className={cx('echo-shadow')}>
+        <Image
+          src={WEBPS.landing.echoShadow.url}
+          alt={WEBPS.landing.echoShadow.alt}
+          fill
+          priority
+          className={cx('echo-shadow-image')}
+        />
+      </div>
+      <div ref={echoRef} className={cx('echo')}>
+        <Image src={WEBPS.landing.echo.url} alt={WEBPS.landing.echo.alt} fill priority className={cx('echo-image')} />
+      </div>
       <div className={cx('side-scroll', 'left')}>
         <ul className={cx('scroll-content', 'left')}>
           {GAME_NAME_LIST_EN.map((gameName, index) => (

--- a/src/components/layout/Banner/Banner.module.scss
+++ b/src/components/layout/Banner/Banner.module.scss
@@ -6,10 +6,13 @@
     height: 32rem;
   }
 
+  position: relative;
   width: 100%;
   height: 46rem;
-  background-position: center;
-  background-size: cover;
+
+  &-image {
+    @include image-center-cover;
+  }
 
   &-game {
     @include inline-flexbox(start);

--- a/src/components/layout/Banner/index.tsx
+++ b/src/components/layout/Banner/index.tsx
@@ -18,7 +18,7 @@ const Banner = () => {
 
   return (
     <section className={cx('banner')}>
-      <Image src={url} alt={alt} fill priority sizes='100%' className={cx('banner-image')} />
+      <Image src={url} alt={alt} fill priority sizes='100%' className={cx('banner-image')} unoptimized />
       <div className={cx('banner-game')}>
         <h1 className={cx('banner-game-name')}>{gameName}</h1>
       </div>

--- a/src/components/layout/Banner/index.tsx
+++ b/src/components/layout/Banner/index.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 
 import classNames from 'classnames/bind';
@@ -13,10 +14,11 @@ const Banner = () => {
   const { game } = router.query;
   if (!game) return;
   const gameName = GAME_PATH_NAME_TO_GAME_NAME_EN[game as keyof typeof GAME_PATH_NAME_TO_GAME_NAME_EN];
-  const { url } = WEBPS.banner[gameName as keyof typeof WEBPS.banner];
+  const { url, alt } = WEBPS.banner[gameName as keyof typeof WEBPS.banner];
 
   return (
-    <section className={cx('banner')} style={{ backgroundImage: `url(${url})` }}>
+    <section className={cx('banner')}>
+      <Image src={url} alt={alt} fill priority sizes='100%' className={cx('banner-image')} />
       <div className={cx('banner-game')}>
         <h1 className={cx('banner-game-name')}>{gameName}</h1>
       </div>

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -59,6 +59,21 @@ export const WEBPS = {
     url: '/images/auth-background.webp',
     alt: '로그인/회원가입 배경화면',
   },
+
+  landing: {
+    echo: {
+      url: '/images/landing-echo.webp',
+      alt: '에코',
+    },
+    echoShadow: {
+      url: '/images/landing-echo-shadow.webp',
+      alt: '에코 그림자',
+    },
+    echoBackground: {
+      url: '/images/landing-echo-background.webp',
+      alt: '에코 배경',
+    },
+  },
 };
 
 export const SVGS = {

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -54,6 +54,11 @@ export const WEBPS = {
       alt: '서버 에러',
     },
   },
+
+  auth: {
+    url: '/images/auth-background.webp',
+    alt: '로그인/회원가입 배경화면',
+  },
 };
 
 export const SVGS = {

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -33,13 +33,6 @@ export const WEBPS = {
     },
   },
 
-  defaultBanner: {
-    스포츠: '/images/default-banner-LOL.webp',
-    투어: '/images/default-banner-BG.webp',
-    관광: '/images/default-banner-OW.webp',
-    웰빙: '/images/default-banner-MC.webp',
-  },
-
   errorPage: {
     error404: {
       url: '/images/404.webp',

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -1,9 +1,21 @@
 export const WEBPS = {
   banner: {
-    ['LEAGUE OF LEGENDS']: { url: '/images/banner-LOL.webp' },
-    ['BATTLEGROUNDS']: { url: '/images/banner-BG.webp' },
-    ['OVERWATCH 2']: { url: '/images/banner-OW.webp' },
-    ['MINECRAFT']: { url: '/images/banner-MC.webp' },
+    'LEAGUE OF LEGENDS': {
+      url: '/images/banner-LOL.webp',
+      alt: '롤 배너 이미지',
+    },
+    BATTLEGROUNDS: {
+      url: '/images/banner-BG.webp',
+      alt: '배그 배너 이미지',
+    },
+    'OVERWATCH 2': {
+      url: '/images/banner-OW.webp',
+      alt: '오버워치 배너 이미지',
+    },
+    MINECRAFT: {
+      url: '/images/banner-MC.webp',
+      alt: '마인크래프트 배너 이미지',
+    },
   },
 
   match: {

--- a/src/styles/mixins/_image.scss
+++ b/src/styles/mixins/_image.scss
@@ -3,3 +3,14 @@
   height: 100%;
   object-fit: $type;
 }
+
+@mixin image-center-cover() {
+  object-fit: cover;
+  object-position: center;
+}
+
+@mixin image-background() {
+  @include image-center-cover;
+
+  z-index: $glitch-1-level;
+}


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #300 
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [X] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- CSS의 background-image 속성을 사용한 큰 이미지들을 Image 태그로 대신함

## 설명

### 📌 UI
- 랜딩페이지의 에코+에코그림자+배경이미지 Image 태그로 변경
- 게시글 리스트 및 게시글 등록/수정 페이지의 배너 이미지를 Image 태그로 변경
- 로그인/회원가입 페이지의 배경 이미지를 Image 태그로 변경

## 리뷰 요구사항
- Image 태그를 사용하니깐 화질이 떨어집니다. merge 하기 전에 이 브랜치를 로컬에서 받아서 한번씩 확인해보시면 좋을것 같습니다!
- [이 게시글](https://www.inflearn.com/questions/949167/next-image-%EC%A7%88%EB%AC%B8) 을 읽고 `unoptimized` 속성을 적용해보니 원본 화질로 돌아왔으나, 아무래도 최적화를 끄는 옵션이다 보니 성능상 큰 이점은 없었습니다..!

### Image 태그 적용 전
![image](https://github.com/sprint-team3/GGF/assets/43297823/e549d149-9d40-4421-b606-e7cf2fa20708)
![image](https://github.com/sprint-team3/GGF/assets/43297823/78e3a855-89ba-47ed-855f-a7565256e77a)

---

### Image 태그 적용 후
![image](https://github.com/sprint-team3/GGF/assets/43297823/c9d13a1d-bed4-4719-8208-8f9d758aff86)
![image](https://github.com/sprint-team3/GGF/assets/43297823/de54a2a7-50d8-47d0-9f45-50bd06a641f9)

---

### Image 태그에 unoptimized 적용 후
![image](https://github.com/sprint-team3/GGF/assets/43297823/45ced52a-0e80-4821-a982-9b4d91eb19b2)
![image](https://github.com/sprint-team3/GGF/assets/43297823/dd5b63da-9fff-486a-832b-06a1c858a0a1)



