### PR TITLE
Refactor: 마이페이지에서 계정관리 페이지로 이동하는 아이콘 추가

### DIFF
--- a/src/components/commons/ProfileSummary/index.tsx
+++ b/src/components/commons/ProfileSummary/index.tsx
@@ -1,10 +1,16 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
 import classNames from 'classnames/bind';
+
+import { SVGS } from '@/constants';
 
 import Avatar from '@/components/commons/Avatar';
 
 import styles from './profileSummary.module.scss';
 
 const cx = classNames.bind(styles);
+const { url, alt } = SVGS.button.setting;
 
 type ProfileSummaryProps = {
   nickname: string;
@@ -26,7 +32,12 @@ const ProfileSummary = ({
       <div className={cx('profile-summary')}>
         <Avatar size='medium' profileImageUrl={profileImageUrl} />
         <div className={cx('profile-summary-info')}>
-          <span className={cx('profile-summary-info-nickname')}>{nickname}</span>
+          <div className={cx('profile-summary-info-profile')}>
+            <span className={cx('profile-summary-info-nickname')}>{nickname}</span>
+            <Link href={'/account'}>
+              <Image src={url} alt={alt} width={18} height={18} />
+            </Link>
+          </div>
           <span className={cx('profile-summary-info-email')}>{email}</span>
         </div>
       </div>

--- a/src/components/commons/ProfileSummary/profileSummary.module.scss
+++ b/src/components/commons/ProfileSummary/profileSummary.module.scss
@@ -50,6 +50,10 @@
     }
 
     &-info {
+      &-profile {
+        @include flexbox(start, center, 0.2rem);
+      }
+
       &-nickname {
         @include text-style(16);
 


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 마이페이지에서 계정관리 페이지로 이동할 수 있는 setting 아이콘을 추가했습니다.

## 설명

### 📌 기능
-

### 📌 UI
-

### 📌 Props
-

### 📌 사용하기
-

## 스크린샷
<img width="1196" alt="스크린샷 2024-04-03 오후 8 37 07" src="https://github.com/sprint-team3/GGF/assets/77719310/78b05e34-99e5-4902-9963-95785d717118">

