### PR TITLE
Hotfix : CSR 토큰 갱신 로직 무한 루프 버그 해결

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -4,6 +4,7 @@ import { Account } from '@/types';
 
 import instance from './axios';
 import ssrInstance from './ssrInstance';
+import userInstance from './userInstance';
 
 export const Auth = {
   /**
@@ -20,7 +21,7 @@ export const Auth = {
    */
   renewToken: (type: 'CSR' | 'SSR') => {
     if (type === 'CSR') {
-      return instance.post(`${AUTH_API}${TOKENS_API}`);
+      return userInstance.post(`${AUTH_API}${TOKENS_API}`);
     } else {
       return ssrInstance.post(`${AUTH_API}${TOKENS_API}`);
     }

--- a/src/apis/userInstance.ts
+++ b/src/apis/userInstance.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+import { getCSRCookie } from '@/utils';
+
+const userInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  timeout: 5000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+userInstance.interceptors.request.use(
+  (config) => {
+    const { accessToken, refreshToken } = getCSRCookie();
+
+    if (!accessToken && refreshToken) {
+      config.headers['Authorization'] = `Bearer ${refreshToken}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
+
+export default userInstance;


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

1. CSR 토큰 갱신에 필요한 userInstance 생성했습니다.
2. CSR renewToken 메서드 사용시 기존 instance 대신 userInstance 사용하도록 했습니다.
3. userInstance에서 interceptor로 refreshToken을 authorization header에 첨부하도록 했습니다.
4. 기존 axios.ts의 instance에서 토큰 갱신 후 액세스토큰을 반영하기 위해 쿠키에서 토큰을 새로 꺼내와서 넣도록 수정했습니다.