### PR TITLE
Refactor: 등록 페이지의 모집 유형 기본 값을 동적으로 수정

### DIFF
--- a/src/components/createPage/PostForm/index.tsx
+++ b/src/components/createPage/PostForm/index.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router';
+
 import { useEffect, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -81,7 +83,10 @@ const PostForm = ({ category }: PostFormProps) => {
   });
 
   // 모집 유형 관련
-  const [price, setPrice] = useState(0);
+  const router = useRouter();
+  const { postType } = router.query;
+  const defaultPostType = Number(postType) || 0;
+  const [price, setPrice] = useState(defaultPostType);
 
   const handlePriceClick = (value: number) => {
     setPrice(value);
@@ -234,7 +239,13 @@ const PostForm = ({ category }: PostFormProps) => {
               <form className={cx('post-form-input-content')}>
                 <fieldset className={cx('post-form-input-content-price')}>
                   <legend>모집 유형</legend>
-                  <InputRadio name='price' label='모집 유형' radioList={PRICE_RADIO_LIST} onClick={handlePriceClick} />
+                  <InputRadio
+                    name='price'
+                    label='모집 유형'
+                    radioList={PRICE_RADIO_LIST}
+                    onClick={handlePriceClick}
+                    defaultPostType={defaultPostType}
+                  />
                 </fieldset>
                 <div className={cx('post-form-input-content-container')}>
                   <fieldset className={cx('post-form-input-content-title')}>

--- a/src/components/layout/header/Menu/index.tsx
+++ b/src/components/layout/header/Menu/index.tsx
@@ -27,7 +27,10 @@ const Menu = () => {
         {GAME_NAME_LIST_EN.map((game, index) => (
           <li key={`menu-${index}`}>
             <Link
-              href={`/${formatGameToLink(game)}`}
+              href={{
+                pathname: `/${formatGameToLink(game)}`,
+                query: { postType: 'all' },
+              }}
               className={cx('menu-game', {
                 'menu-game-activated': isGameActivated(index),
               })}

--- a/src/components/listPage/PostList/index.tsx
+++ b/src/components/listPage/PostList/index.tsx
@@ -61,14 +61,23 @@ const PostList = ({ isLoggedIn, activitiesData: initialDataList, isLoading }: Po
 
   const isEmptyPost = !isLoading && totalCount === 0;
 
-  const handleTabChange = (selectedId: number | string) => setSelectFilter({ price: selectedId });
+  const handleTabChange = (selectedId: number | string) => {
+    setSelectFilter({ price: selectedId });
+    router.push({
+      pathname: router.pathname,
+      query: { ...router.query, postType: selectedId },
+    });
+  };
 
   const handleOptionChange = (value: string | number) => setSortOption((prev) => ({ ...prev, order: value as Order }));
 
   const handlePageChange = (pageNumber: number) => setPage(pageNumber);
 
   const handleCreateButtonClick = () => {
-    router.push(`/${game}/create`);
+    router.push({
+      pathname: `/${game}/create`,
+      query: { postType: selectFilter.price },
+    });
   };
 
   return (

--- a/src/pages/[game]/create/index.tsx
+++ b/src/pages/[game]/create/index.tsx
@@ -1,7 +1,7 @@
 import { GetServerSidePropsContext } from 'next';
 
 import { META_DATA, GAME_T0_CATEGORY, PAGE_PATHS } from '@/constants';
-import { formatLinkToGame, isValidGameName, requiresLogin } from '@/utils';
+import { formatLinkToGame, isValidGameName, isValidPostType, requiresLogin } from '@/utils';
 
 import CreatePageContent from '@/components/createPage/CreatePageContent';
 import Layout from '@/components/layout/Layout';
@@ -13,9 +13,11 @@ const { title, description, keywords } = META_DATA.create;
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const game = context.params?.game;
-  const isValid = isValidGameName(game as string);
+  const isValidParam = isValidGameName(game as string);
+  const query = context.query;
+  const isValidQuery = isValidPostType(String(query.postType));
 
-  if (!isValid) {
+  if (!isValidParam || !isValidQuery) {
     return {
       redirect: {
         destination: PAGE_PATHS.mainList,

--- a/src/utils/isValidGameName.ts
+++ b/src/utils/isValidGameName.ts
@@ -1,5 +1,17 @@
+import { POST_TYPES_FOR_LISTPAGE } from '@/constants';
+
 import { LinkName } from '@/types';
 
 export const isValidGameName = (game: string): game is LinkName => {
   return ['league-of-legends', 'battlegrounds', 'overwatch-2', 'minecraft'].includes(game);
+};
+
+export const isValidPostType = (query: string) => {
+  const validPostTypes = String(POST_TYPES_FOR_LISTPAGE.map((item) => item.id));
+
+  if (!validPostTypes.includes(query)) {
+    return false;
+  }
+
+  return true;
 };


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->
- Menu에서 게임 선택 시 리스트 페이지 url에 query를 추가하도록 수정
- 리스트 페이지에서 탭 선택 시 query가 동적으로 변하도록 수정
- 리스트 페이지에서 등록 버튼 클릭 시 현재 query 값이 등록 페이지의 url에 전달되도록 수정
- 등록 페이지에서 query의 값을 모집 유형의 기본 값으로 사용하도록 수정
- 등록 페이지의 query 값이 적절하지 않을 경우 해당 리스트 페이지로 이동시키는 로직 추가
- 적절한 query 값을 확인하는 유틸 함수 추가


## 설명

### 📌 기능
-

### 📌 UI
-

### 📌 Props
-

### 📌 사용하기
-

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 🎥 모션 영상

### 📸 디바이스별 스크린샷

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
