### PR TITLE
Refactor[#344]:  예약하기 패널, 캘린더 리팩터링(react-query 로직 분리, 스키마 분리, 불필요한 useEffect 정리)

### DIFF
--- a/src/apis/myReservations/schema.ts
+++ b/src/apis/myReservations/schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+const { minPlayMember, availableSchedule } = ERROR_MESSAGE;
+import { ERROR_MESSAGE } from '@/constants';
+
+export const ReservationSchema = z.object({
+  headCount: z.number().min(1, { message: minPlayMember.min }),
+  scheduleId: z.number().refine((id) => id !== 0, { message: availableSchedule.min }),
+});

--- a/src/apis/myReservations/schema.ts
+++ b/src/apis/myReservations/schema.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 
-const { minPlayMember, availableSchedule } = ERROR_MESSAGE;
 import { ERROR_MESSAGE } from '@/constants';
+
+const { minPlayMember, availableSchedule } = ERROR_MESSAGE;
 
 export const ReservationSchema = z.object({
   headCount: z.number().min(1, { message: minPlayMember.min }),

--- a/src/components/postDetail/reservationPanel/Calendar/data-access/useGetScheduleList.ts
+++ b/src/components/postDetail/reservationPanel/Calendar/data-access/useGetScheduleList.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
+import Activities from '@/apis/activities';
+import { QUERY_KEYS } from '@/apis/queryKeys';
+
+type useGetScheduleListProps = {
+  activityId: number;
+  year: string;
+  month: string;
+};
+
+export const useGetScheduleList = ({ activityId, year, month }: useGetScheduleListProps) => {
+  const { data: initialScheduleData, isSuccess } = useQuery({
+    queryKey: QUERY_KEYS.activities.getScheduleList(activityId, year, month),
+    queryFn: () => Activities.getScheduleList({ activityId, year, month }),
+  });
+
+  return { initialScheduleData, isSuccess };
+};

--- a/src/components/postDetail/reservationPanel/Calendar/index.tsx
+++ b/src/components/postDetail/reservationPanel/Calendar/index.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames/bind';
 import dayjs from 'dayjs';
 
 import { SVGS } from '@/constants';
-import { formatPadWithZero, getMonthName } from '@/utils';
+import { formatPadWithZero, getMonthString } from '@/utils';
 
 import { useGetScheduleList } from '@/components/postDetail/reservationPanel/Calendar/data-access/useGetScheduleList';
 import NoAvailableSchedule from '@/components/postDetail/reservationPanel/NoAvailableSchedule';
@@ -45,7 +45,7 @@ const Calendar = ({ activityId, setAvailableTimes, setIsNoSchedule }: CalenderPr
     month: formatPadWithZero(selectedMonth),
   });
 
-  const monthName = getMonthName(selectedMonth);
+  const monthName = getMonthString(selectedMonth);
   const availableSchedules: ReservationAvailableSchedule[] = initialScheduleData?.data || [];
   const isAllSchedulesReserved = availableSchedules.length === 0;
   const initialDate = availableSchedules[0]?.date || '';

--- a/src/components/postDetail/reservationPanel/Calendar/index.tsx
+++ b/src/components/postDetail/reservationPanel/Calendar/index.tsx
@@ -18,7 +18,7 @@ import styles from './Calendar.module.scss';
 
 const cx = classNames.bind(styles);
 const { left, right } = SVGS.arrow;
-const maxReservationDate = 30;
+const MAX_RESERVATION_DATE = 30;
 
 type CalenderProps = {
   activityId: number;
@@ -34,7 +34,7 @@ const Calendar = ({ activityId, setAvailableTimes, setIsNoSchedule }: CalenderPr
   const { url: arrowRightUrl, alt: arrowRightAlt } = arrowRightHover ? right.active : right.default;
 
   const today = dayjs();
-  const maxDate = today.add(maxReservationDate, 'day');
+  const maxDate = today.add(MAX_RESERVATION_DATE, 'day');
 
   const [selectedYear, setSelectedYear] = useState(today.year());
   const [selectedMonth, setSelectedMonth] = useState(today.month() + 1);

--- a/src/components/postDetail/reservationPanel/Calendar/index.tsx
+++ b/src/components/postDetail/reservationPanel/Calendar/index.tsx
@@ -2,24 +2,23 @@ import Image from 'next/image';
 
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
-import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 import dayjs from 'dayjs';
 
-import Activities from '@/apis/activities';
-import { QUERY_KEYS } from '@/apis/queryKeys';
 import { SVGS } from '@/constants';
-import { formatPadWithZero } from '@/utils';
+import { formatPadWithZero, getMonthName } from '@/utils';
 
+import { useGetScheduleList } from '@/components/postDetail/reservationPanel/Calendar/data-access/useGetScheduleList';
 import NoAvailableSchedule from '@/components/postDetail/reservationPanel/NoAvailableSchedule';
 import useToggleButton from '@/hooks/useToggleButton';
 
-import { ReservationAvailableSchedule, AvailableScheduleTimes } from '@/types';
+import { ReservationAvailableSchedule, AvailableScheduleTimes, AvailableTimesOptions } from '@/types';
 
 import styles from './Calendar.module.scss';
 
 const cx = classNames.bind(styles);
 const { left, right } = SVGS.arrow;
+const maxReservationDate = 30;
 
 type CalenderProps = {
   activityId: number;
@@ -27,61 +26,41 @@ type CalenderProps = {
   setIsNoSchedule: Dispatch<SetStateAction<boolean>>;
 };
 
-type AvailableTimesOptions = {
-  title: string;
-  value: number;
-};
-
 const Calendar = ({ activityId, setAvailableTimes, setIsNoSchedule }: CalenderProps) => {
-  const today = dayjs();
-
-  const [selectedYear, setSelectedYear] = useState(today.year());
-  const [selectedMonth, setSelectedMonth] = useState(today.month() + 1);
-
-  const year = formatPadWithZero(selectedYear);
-  const month = formatPadWithZero(selectedMonth);
-
-  const { data: initialScheduleData, isSuccess } = useQuery({
-    queryKey: QUERY_KEYS.activities.getScheduleList(activityId, year, month),
-    queryFn: () => Activities.getScheduleList({ activityId, year, month }),
-  });
-
-  const availableSchedules: ReservationAvailableSchedule[] = initialScheduleData?.data || [];
-  const initialDate = availableSchedules[0]?.date || '';
-  const isAllSchedulesReserved = availableSchedules.length === 0;
-
-  const [monthName, setMonthName] = useState('');
-  const monthNameFormat = dayjs()
-    .month(selectedMonth - 1)
-    .format('MMMM');
-  const maxDate = today.add(30, 'day');
-
-  const [selectedDate, setSelectedDate] = useState(initialDate);
-
   const { isVisible: arrowLeftHover, handleToggleClick: arrowLeftClick } = useToggleButton();
   const { isVisible: arrowRightHover, handleToggleClick: arrowRightClick } = useToggleButton();
 
   const { url: arrowLeftUrl, alt: arrowLeftAlt } = arrowLeftHover ? left.active : left.default;
   const { url: arrowRightUrl, alt: arrowRightAlt } = arrowRightHover ? right.active : right.default;
 
+  const today = dayjs();
+  const maxDate = today.add(maxReservationDate, 'day');
+
+  const [selectedYear, setSelectedYear] = useState(today.year());
+  const [selectedMonth, setSelectedMonth] = useState(today.month() + 1);
+
+  const { initialScheduleData, isSuccess } = useGetScheduleList({
+    activityId,
+    year: String(selectedYear),
+    month: formatPadWithZero(selectedMonth),
+  });
+
+  const monthName = getMonthName(selectedMonth);
+  const availableSchedules: ReservationAvailableSchedule[] = initialScheduleData?.data || [];
+  const isAllSchedulesReserved = availableSchedules.length === 0;
+  const initialDate = availableSchedules[0]?.date || '';
+
+  const [selectedDate, setSelectedDate] = useState(initialDate);
+
   const updateAvailableTimes = (value: string) => {
     setSelectedDate(value);
-    let updatedTimes: AvailableTimesOptions[] = [];
-
-    const selectedDateSchedule = availableSchedules.find((a) => a.date === value);
-    if (selectedDateSchedule) {
-      updatedTimes = selectedDateSchedule.times.map((item: AvailableScheduleTimes) => ({
-        value: item.id,
-        title: `${item.startTime}-${item.endTime}`,
-      }));
-    } else {
-      updatedTimes = [
-        {
-          title: '예약 가능한 시간대가 없습니다.',
-          value: 0,
-        },
-      ];
-    }
+    const selectedDateSchedule = availableSchedules.find((schedule) => schedule.date === value);
+    const updatedTimes = selectedDateSchedule
+      ? selectedDateSchedule.times.map((item: AvailableScheduleTimes) => ({
+          value: item.id,
+          title: `${item.startTime}-${item.endTime}`,
+        }))
+      : [{ title: '예약 가능한 시간대가 없습니다.', value: 0 }];
 
     setAvailableTimes(updatedTimes);
   };
@@ -107,14 +86,10 @@ const Calendar = ({ activityId, setAvailableTimes, setIsNoSchedule }: CalenderPr
   };
 
   useEffect(() => {
-    if (isSuccess) {
-      setSelectedDate(initialDate);
-      updateAvailableTimes(initialDate);
-    }
+    if (isSuccess) updateAvailableTimes(initialDate);
 
     setIsNoSchedule(isAllSchedulesReserved);
-    setMonthName(monthNameFormat);
-  }, [isSuccess, availableSchedules, selectedDate, isAllSchedulesReserved, monthNameFormat]);
+  }, [isSuccess, initialDate, isAllSchedulesReserved]);
 
   useEffect(() => {
     if (selectedDate) {

--- a/src/components/postDetail/reservationPanel/ReservationPanel/data-access/useCreateReservation.ts
+++ b/src/components/postDetail/reservationPanel/ReservationPanel/data-access/useCreateReservation.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import Activities from '@/apis/activities';
+
+type useCreateReservationProps = {
+  handleToggleModal: (modalKey: string) => void;
+};
+
+export const useCreateReservation = ({ handleToggleModal }: useCreateReservationProps) => {
+  const { mutate: reservationMutation } = useMutation({
+    mutationFn: Activities.createReservation,
+    onSuccess: () => {
+      handleToggleModal('submitSuccessModal');
+    },
+    onError: (error) => {
+      if ((error as AxiosError)?.response?.status === 400) {
+        handleToggleModal('pastScheduleAlertModal');
+      }
+
+      if ((error as AxiosError)?.response?.status === 409) {
+        handleToggleModal('reservationUnavailableAlertModal');
+      }
+    },
+  });
+
+  return { reservationMutation };
+};

--- a/src/types/myReservations.ts
+++ b/src/types/myReservations.ts
@@ -30,6 +30,11 @@ export type CreateReviewParams = {
   content: string;
 };
 
+export type AvailableTimesOptions = {
+  title: string;
+  value: number;
+};
+
 export type MyReservationsStatus = 'pending' | 'confirmed' | 'declined' | 'canceled' | 'completed';
 
 export type MyReservationsStatusKR = '신청' | '승인' | '거절' | '취소' | '종료';

--- a/src/utils/getDate.ts
+++ b/src/utils/getDate.ts
@@ -137,3 +137,11 @@ export const getDayDiff = (seletedDate: string) => {
   const today = dayjs();
   return today.diff(seletedDate, 'days');
 };
+
+export const getMonthName = (selectedMonth: number) => {
+  const monthNameFormat = dayjs()
+    .month(selectedMonth - 1)
+    .format('MMMM');
+
+  return monthNameFormat;
+};

--- a/src/utils/getDate.ts
+++ b/src/utils/getDate.ts
@@ -137,11 +137,3 @@ export const getDayDiff = (seletedDate: string) => {
   const today = dayjs();
   return today.diff(seletedDate, 'days');
 };
-
-export const getMonthName = (selectedMonth: number) => {
-  const monthNameFormat = dayjs()
-    .month(selectedMonth - 1)
-    .format('MMMM');
-
-  return monthNameFormat;
-};


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서

- issue: #344 
- close #344 

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 예약하기 패널, 캘린더 리팩터링

## 설명

### 📌 기능
- 선택된 달을 영문으로 변환해주는 유틸함수 적용(기존)
- 예약관련 타입 추가
- 예약관련 스키마 파일 분리
- useQuery 외부 로직으로 분리
- 불필요한 useEffect 정리

### 📌 UI
-

### 📌 Props
-

### 📌 사용하기
-

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
### 🎥 모션 영상

### 📸 디바이스별 스크린샷

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
